### PR TITLE
Bump gs-chunked-io, update gs client instantiation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 google-cloud-storage
-gs-chunked-io >= 0.2.7
+gs-chunked-io >= 0.2.10
 firecloud

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
-WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT', None)
+WORKSPACE_GOOGLE_PROJECT = os.environ.get('GCLOUD_PROJECT', None)
 WORKSPACE_BUCKET = os.environ.get('WORKSPACE_BUCKET', None)
 DRS_SCHEMA = 'drs://'
 GS_SCHEMA = 'gs://'

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -2,6 +2,8 @@ import os
 
 WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
 WORKSPACE_GOOGLE_PROJECT = os.environ.get('GCLOUD_PROJECT', None)
+# For a list of gcloud project related environment variables, see:
+# https://cloud.google.com/functions/docs/env-var#environment_variables_set_automatically
 WORKSPACE_BUCKET = os.environ.get('WORKSPACE_BUCKET', None)
 DRS_SCHEMA = 'drs://'
 GS_SCHEMA = 'gs://'

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,5 @@
 import os
 
-os.environ['GOOGLE_PROJECT'] = "firecloud-cgl"
+os.environ['GCLOUD_PROJECT'] = "firecloud-cgl"
 os.environ['WORKSPACE_NAME'] = "terra-notebook-utils-tests"
 os.environ['WORKSPACE_BUCKET'] = "gs://fc-9169fcd1-92ce-4d60-9d2d-d19fd326ff10"

--- a/tests/fixtures/populate_workspace_data.py
+++ b/tests/fixtures/populate_workspace_data.py
@@ -12,7 +12,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', "..")) 
 sys.path.insert(0, pkg_root)  # noqa
 
 import tests.config
-WORKSPACE_GOOGLE_PROJECT = os.environ['GOOGLE_PROJECT']
+WORKSPACE_GOOGLE_PROJECT = os.environ['GCLOUD_PROJECT']
 WORKSPACE_NAME = os.environ['WORKSPACE_NAME']
 
 def list_entities():


### PR DESCRIPTION
Something seems to have changed concerning gcloud storage client instantiation, which no longer picked up the correct project id during tests in a compute engine instance.

Switch project id environment variables from GOOGLE_PROJECT to GCLOUD_PROJECT, which corresponds with Google project environment variable [documentation](https://cloud.google.com/functions/docs/env-var#environment_variables_set_automatically).