### PR TITLE
Add VCF file inspection class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-storage
 gs-chunked-io >= 0.2.10
-bgzip
 firecloud
+bgzip >= 0.2.2

--- a/terra_notebook_utils/vcf.py
+++ b/terra_notebook_utils/vcf.py
@@ -1,0 +1,39 @@
+import io
+from multiprocessing import cpu_count
+
+import bgzip
+import gs_chunked_io as gscio
+
+
+cores_available = cpu_count()
+
+
+class VCFInfo:
+    columns = ["chrom", "pos", "id", "ref", "alt", "qual", "filter", "info", "format"]
+    chromosomes = [f"chr{i}" for i in range(1, 23)] + ["chrX"]
+
+    def __init__(self, fileobj):
+        self.header = list()
+        for line in fileobj:
+            line = line.decode("utf-8").strip()
+            if line.startswith("##"):
+                self.header.append(line)
+            elif not line or line.startswith("#"):
+                continue
+            else:
+                first_data_line = line
+                break
+        parts = first_data_line.split("\t", len(self.columns))
+        for key, val in zip(self.columns + ["data"], parts):
+            setattr(self, key, val)
+
+    @classmethod
+    def with_blob(cls, blob, read_buf: memoryview):
+        chunk_size = 1024 * 1024
+        with gscio.AsyncReader(blob, chunks_to_buffer=1, chunk_size=chunk_size) as raw:
+            with bgzip.BGZipAsyncReaderPreAllocated(raw,
+                                                    read_buf,
+                                                    num_threads=cores_available,
+                                                    raw_read_chunk_size=chunk_size) as bgzip_reader:
+                with io.BufferedReader(bgzip_reader) as reader:
+                    return cls(reader)

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -16,7 +16,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests import config
 
 from terra_notebook_utils import WORKSPACE_GOOGLE_PROJECT, WORKSPACE_BUCKET
-from terra_notebook_utils import drs, table, gs, tar_gz, xprofile, progress
+from terra_notebook_utils import drs, table, gs, tar_gz, xprofile, progress, vcf
 
 
 class TestTerraNotebookUtilsTable(unittest.TestCase):
@@ -121,6 +121,16 @@ class TestTerraNotebookUtilsTARGZ(unittest.TestCase):
                 self.assertIsNotNone(blob)
                 age = (datetime.now(pytz.utc) - blob.time_created).total_seconds()
                 self.assertGreater(time.time() - start_time, age)
+
+
+class TestTerraNotebookUtilsVCF(unittest.TestCase):
+    def test_vcf_info(self):
+        key = "consent1/HVH_phs000993_TOPMed_WGS_freeze.8.chr7.hg38.vcf.gz"
+        blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
+        buf = memoryview(bytearray(1024 * 1024 * 50))
+        vcf_info = vcf.VCFInfo.with_blob(blob, buf)
+        self.assertEqual("chr7", vcf_info.chrom)
+        self.assertEqual("10007", vcf_info.pos)
 
 
 class TestTerraNotebookUtilsProgress(unittest.TestCase):


### PR DESCRIPTION
This is useful to gather information about VCFs without downloading and extracting the entire file.