### PR TITLE
Add support for named pipes to GS blob objects

### DIFF
--- a/terra_notebook_utils/pipes.py
+++ b/terra_notebook_utils/pipes.py
@@ -1,0 +1,74 @@
+import os
+import time
+from uuid import uuid4
+from contextlib import AbstractContextManager
+from multiprocessing import Process
+
+import gs_chunked_io as gscio
+
+from terra_notebook_utils import gs
+
+
+class BlobReaderProcess(AbstractContextManager):
+    def __init__(self, bucket_name, key, filepath=None):
+        self.filepath = filepath or f"/tmp/{uuid4()}"
+        os.mkfifo(self.filepath)
+        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
+        self.proc.start()
+        self._closed = False
+
+    def run(self, bucket_name, key, filepath):
+        fd = os.open(filepath, os.O_WRONLY)
+        blob = gs.get_client().bucket(bucket_name).get_blob(key)
+        blob_reader = gscio.AsyncReader(blob, chunks_to_buffer=1)
+        while True:
+            data = bytearray(blob_reader.read(blob_reader.chunk_size))
+            if not data:
+                break
+            while data:
+                try:
+                    k = os.write(fd, data)
+                    data = data[k:]
+                except BrokenPipeError:
+                    time.sleep(1)
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self.proc.join(1)
+            os.unlink(self.filepath)
+            if not self.proc.exitcode:
+                self.proc.terminate()
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+
+class BlobWriterProcess(AbstractContextManager):
+    def __init__(self, bucket_name, key, filepath=None):
+        self.filepath = filepath or f"/tmp/{uuid4()}"
+        os.mkfifo(self.filepath)
+        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
+        self.proc.start()
+        self._closed = False
+
+    def run(self, bucket_name, key, filepath):
+        bucket = gs.get_client().bucket(bucket_name)
+        with gscio.Writer(key, bucket) as blob_writer:
+            with open(filepath, "rb") as fh:
+                while True:
+                    data = fh.read(blob_writer.chunk_size)
+                    if not data:
+                        break
+                    blob_writer.write(data)
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self.proc.join(300)
+            os.unlink(self.filepath)
+            if not self.proc.exitcode:
+                self.proc.terminate()
+
+    def __exit__(self, *args, **kwargs):
+        self.close()

--- a/terra_notebook_utils/pipes.py
+++ b/terra_notebook_utils/pipes.py
@@ -65,7 +65,7 @@ class BlobWriterProcess(AbstractContextManager):
     def close(self):
         if not self._closed:
             self._closed = True
-            self.proc.join(300)
+            self.proc.join(300)  # TODO: Consider inter-process communication to know when it's safe to close
             os.unlink(self.filepath)
             if not self.proc.exitcode:
                 self.proc.terminate()

--- a/terra_notebook_utils/vcf.py
+++ b/terra_notebook_utils/vcf.py
@@ -1,9 +1,6 @@
 import io
-import os
-import time
 from uuid import uuid4
-from contextlib import AbstractContextManager
-from multiprocessing import Process, cpu_count
+from multiprocessing import cpu_count
 
 import bgzip
 import gs_chunked_io as gscio
@@ -12,71 +9,6 @@ from terra_notebook_utils import gs, xprofile
 
 
 cores_available = cpu_count()
-
-
-class BlobReaderProcess(AbstractContextManager):
-    def __init__(self, bucket_name, key):
-        self.filepath = f"/tmp/{uuid4()}.vcf.bgz"
-        os.mkfifo(self.filepath)
-        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
-        self.proc.start()
-        self._closed = False
-
-    def run(self, bucket_name, key, filepath):
-        fd = os.open(filepath, os.O_WRONLY)
-        blob = gs.get_client().bucket(bucket_name).get_blob(key)
-        blob_reader = gscio.AsyncReader(blob, chunks_to_buffer=1)
-        while True:
-            data = bytearray(blob_reader.read(blob_reader.chunk_size))
-            if not data:
-                break
-            while data:
-                try:
-                    k = os.write(fd, data)
-                    data = data[k:]
-                except BrokenPipeError:
-                    time.sleep(1)
-
-    def close(self):
-        if not self._closed:
-            self._closed = True
-            self.proc.join(1)
-            os.unlink(self.filepath)
-            if not self.proc.exitcode:
-                self.proc.terminate()
-
-    def __exit__(self, *args, **kwargs):
-        self.close()
-
-
-class BlobWriterProcess(AbstractContextManager):
-    def __init__(self, bucket_name, key):
-        self.filepath = f"/tmp/{uuid4()}.vcf.bgz"
-        os.mkfifo(self.filepath)
-        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
-        self.proc.start()
-        self._closed = False
-
-    def run(self, bucket_name, key, filepath):
-        bucket = gs.get_client().bucket(bucket_name)
-        with gscio.Writer(key, bucket) as blob_writer:
-            with open(filepath, "rb") as fh:
-                while True:
-                    data = fh.read(blob_writer.chunk_size)
-                    if not data:
-                        break
-                    blob_writer.write(data)
-
-    def close(self):
-        if not self._closed:
-            self._closed = True
-            self.proc.join(300)
-            os.unlink(self.filepath)
-            if not self.proc.exitcode:
-                self.proc.terminate()
-
-    def __exit__(self, *args, **kwargs):
-        self.close()
 
 
 class VCFInfo:

--- a/terra_notebook_utils/vcf.py
+++ b/terra_notebook_utils/vcf.py
@@ -1,6 +1,9 @@
 import io
+import os
+import time
 from uuid import uuid4
-from multiprocessing import cpu_count
+from contextlib import AbstractContextManager
+from multiprocessing import Process, cpu_count
 
 import bgzip
 import gs_chunked_io as gscio
@@ -9,6 +12,71 @@ from terra_notebook_utils import gs, xprofile
 
 
 cores_available = cpu_count()
+
+
+class BlobReaderProcess(AbstractContextManager):
+    def __init__(self, bucket_name, key):
+        self.filepath = f"/tmp/{uuid4()}.vcf.bgz"
+        os.mkfifo(self.filepath)
+        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
+        self.proc.start()
+        self._closed = False
+
+    def run(self, bucket_name, key, filepath):
+        fd = os.open(filepath, os.O_WRONLY)
+        blob = gs.get_client().bucket(bucket_name).get_blob(key)
+        blob_reader = gscio.AsyncReader(blob, chunks_to_buffer=1)
+        while True:
+            data = bytearray(blob_reader.read(blob_reader.chunk_size))
+            if not data:
+                break
+            while data:
+                try:
+                    k = os.write(fd, data)
+                    data = data[k:]
+                except BrokenPipeError:
+                    time.sleep(1)
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self.proc.join(1)
+            os.unlink(self.filepath)
+            if not self.proc.exitcode:
+                self.proc.terminate()
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+
+class BlobWriterProcess(AbstractContextManager):
+    def __init__(self, bucket_name, key):
+        self.filepath = f"/tmp/{uuid4()}.vcf.bgz"
+        os.mkfifo(self.filepath)
+        self.proc = Process(target=self.run, args=(bucket_name, key, self.filepath))
+        self.proc.start()
+        self._closed = False
+
+    def run(self, bucket_name, key, filepath):
+        bucket = gs.get_client().bucket(bucket_name)
+        with gscio.Writer(key, bucket) as blob_writer:
+            with open(filepath, "rb") as fh:
+                while True:
+                    data = fh.read(blob_writer.chunk_size)
+                    if not data:
+                        break
+                    blob_writer.write(data)
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self.proc.join(300)
+            os.unlink(self.filepath)
+            if not self.proc.exitcode:
+                self.proc.terminate()
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
 
 
 class VCFInfo:

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import io
 import os
 import sys
 import time
@@ -6,6 +7,7 @@ import unittest
 import glob
 import pytz
 from uuid import uuid4
+from random import randint
 from datetime import datetime
 
 import gs_chunked_io as gscio
@@ -124,6 +126,41 @@ class TestTerraNotebookUtilsTARGZ(unittest.TestCase):
 
 
 class TestTerraNotebookUtilsVCF(unittest.TestCase):
+    def test_blob_reader(self):
+        key = "test_blob_reader_obj"
+        data = os.urandom(1024 * 1024 * 50)
+        with io.BytesIO(data) as fh:
+            gs.get_client().bucket(WORKSPACE_BUCKET).blob(key).upload_from_file(fh)
+        with vcf.BlobReaderProcess(WORKSPACE_BUCKET, key) as reader:
+            in_data = bytearray()
+            with open(reader.filepath, "rb") as fh:
+                while True:
+                    d = fh.read(randint(1024, 1024 * 1024))
+                    if d:
+                        in_data += d
+                    else:
+                        break
+        self.assertEqual(data, in_data)
+
+    def test_blob_writer(self):
+        key = "test_blob_writer_obj"
+        data = os.urandom(1024 * 1024 * 50)
+        with vcf.BlobWriterProcess(WORKSPACE_BUCKET, key) as writer:
+            with open(writer.filepath, "wb") as fh:
+                out_data = bytearray(data)
+                while True:
+                    chunk_size = randint(1024, 1024 * 1024)
+                    to_write = out_data[:chunk_size]
+                    out_data = out_data[chunk_size:]
+                    if to_write:
+                        fh.write(to_write)
+                    else:
+                        break
+
+        with io.BytesIO() as fh:
+            gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key).download_to_file(fh)
+            self.assertEqual(fh.getvalue(), data)
+
     def test_vcf_info(self):
         key = "consent1/HVH_phs000993_TOPMed_WGS_freeze.8.chr7.hg38.vcf.gz"
         blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)


### PR DESCRIPTION
Represent IO streams to cloud objects as files on the local file system.

This allows read/write to bucket objects without downloading their entire contents.