### PR TITLE
[Easy] Update flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=120
-ignore: E301, E302, E305, E401, F401, W503, W504, W605, E252
+ignore: E301, E302, E305, E401, F401, W503, W504, W605, E252, E402


### PR DESCRIPTION
This prevents the (new?) flak8 import warnings:
```
tests/test_terra_notebook_utils.py:20:1: E402 module level import not at top of file
tests/test_terra_notebook_utils.py:21:1: E402 module level import not at top of file
tests/test_terra_notebook_utils.py:22:1: E402 module level import not at top of file
tests/test_terra_notebook_utils.py:23:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:22:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:23:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:24:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:25:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:26:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:27:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:28:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:29:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:30:1: E402 module level import not at top of file
tests/test_terra_notebook_utils_cli.py:31:1: E402 module level import not at top of file
tests/fixtures/populate_workspace_data.py:14:1: E402 module level import not at top of file
```