### PR TITLE
Introduce method to resolve CLI config

### DIFF
--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -7,6 +7,8 @@ import typing
 
 import cli_builder
 
+from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+
 
 class Config:
     info = dict(workspace=None, workspace_google_project=None)
@@ -23,6 +25,15 @@ class Config:
     def write(cls):
         with open(cls.path, "w") as fh:
             fh.write(json.dumps(cls.info, indent=2))
+
+    @classmethod
+    def resolve(cls, default_workspace: str, default_namespace: str):
+        workspace = default_workspace or (cls.info['workspace'] or WORKSPACE_NAME)
+        namespace = default_namespace or (cls.info['workspace_google_project'] or WORKSPACE_GOOGLE_PROJECT)
+        if workspace and namespace is None:
+            from terra_notebook_utils.workspace import get_workspace_namespace
+            namespace = get_workspace_namespace(workspace)
+        return workspace, namespace
 Config.load()
 
 

--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -27,9 +27,9 @@ class Config:
             fh.write(json.dumps(cls.info, indent=2))
 
     @classmethod
-    def resolve(cls, default_workspace: str, default_namespace: str):
-        workspace = default_workspace or (cls.info['workspace'] or WORKSPACE_NAME)
-        namespace = default_namespace or (cls.info['workspace_google_project'] or WORKSPACE_GOOGLE_PROJECT)
+    def resolve(cls, override_workspace: str, override_namespace: str):
+        workspace = override_workspace or (cls.info['workspace'] or WORKSPACE_NAME)
+        namespace = override_namespace or (cls.info['workspace_google_project'] or WORKSPACE_GOOGLE_PROJECT)
         if workspace and namespace is None:
             from terra_notebook_utils.workspace import get_workspace_namespace
             namespace = get_workspace_namespace(workspace)

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -27,6 +27,7 @@ def drs_copy(args: argparse.Namespace):
         tnu drs copy drs://my-drs-id /tmp/doom
         tnu drs copy drs://my-drs-id gs://my-cool-bucket/my-cool-bucket-key
     """
+    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
     drs.copy(args.drs_url, args.dst, args.google_billing_project)
 
 @drs_cli.command("extract-tar-gz", arguments={
@@ -43,4 +44,5 @@ def drs_extract_tar_gz(args: argparse.Namespace):
     assert args.dst_gs_url.startswith("gs://")
     bucket, pfx = args.dst_gs_url[5:].split("/", 1)
     pfx = pfx or None
+    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
     drs.extract_tar_gz(args.drs_url, pfx, bucket, args.google_billing_project)

--- a/terra_notebook_utils/cli/vcf.py
+++ b/terra_notebook_utils/cli/vcf.py
@@ -27,6 +27,7 @@ def head(args: argparse.Namespace):
     """
     Output VCF header.
     """
+    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
     blob = _get_blob(args.path, args.google_billing_project)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)
@@ -39,6 +40,7 @@ def samples(args: argparse.Namespace):
     """
     Output VCF samples.
     """
+    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
     blob = _get_blob(args.path, args.google_billing_project)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)
@@ -51,6 +53,7 @@ def stats(args: argparse.Namespace):
     """
     Output VCF stats.
     """
+    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
     blob = _get_blob(args.path, args.google_billing_project)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)


### PR DESCRIPTION
This allows the CLI to fallback to environment variable configurations. The default heierarchy is:
  - First use values passed in to a CLI command
  - Otherwise use values from the CLI config file
  - Otherwise use environment variable values

depends on #72 