### PR TITLE
Propagate workspace/namespace args to drs methods

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gs-chunked-io >= 0.3.3
 firecloud
 bgzip >= 0.3.0
 cli-builder
+oauth2client

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -5,6 +5,11 @@ from terra_notebook_utils.cli import dispatch, Config
 
 
 drs_cli = dispatch.group("drs", help=drs.__doc__, arguments={
+    "--workspace": dict(
+        type=str,
+        default=None,
+        help="workspace name. If not provided, the configured CLI workspace will be used"
+    ),
     "--google-billing-project": dict(
         type=str,
         required=False,
@@ -27,8 +32,8 @@ def drs_copy(args: argparse.Namespace):
         tnu drs copy drs://my-drs-id /tmp/doom
         tnu drs copy drs://my-drs-id gs://my-cool-bucket/my-cool-bucket-key
     """
-    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
-    drs.copy(args.drs_url, args.dst, args.google_billing_project)
+    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    drs.copy(args.drs_url, args.dst, args.workspace, args.google_billing_project)
 
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),
@@ -44,5 +49,5 @@ def drs_extract_tar_gz(args: argparse.Namespace):
     assert args.dst_gs_url.startswith("gs://")
     bucket, pfx = args.dst_gs_url[5:].split("/", 1)
     pfx = pfx or None
-    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
-    drs.extract_tar_gz(args.drs_url, pfx, bucket, args.google_billing_project)
+    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    drs.extract_tar_gz(args.drs_url, pfx, bucket, args.workspace, args.google_billing_project)

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from random import randint
 from datetime import datetime
 from functools import lru_cache
+from unittest import mock
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import gs_chunked_io as gscio
@@ -84,26 +85,28 @@ class TestTerraNotebookUtilsTable(TestCaseSuppressWarnings):
             table.delete_table(table_name)
 
 
-@testmode("controlled_access")
 class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
-    @classmethod
-    def setUpClass(cls):
-        cls.drs_url = "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35"
+    drs_url = "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35"
 
+    @testmode("controlled_access")
     def test_resolve_drs_for_google_storage(self):
         _, bucket_name, key = drs.resolve_drs_for_gs_storage(self.drs_url)
         self.assertEqual(bucket_name, "topmed-irc-share")
         self.assertEqual(key, "genomes/NWD522743.b38.irc.v1.cram.crai")
 
+    @testmode("controlled_access")
     def test_download(self):
         drs.copy_to_local(self.drs_url, "foo")
 
+    @testmode("controlled_access")
     def test_oneshot_copy(self):
         drs.copy_to_bucket(self.drs_url, "test_oneshot_object")
 
+    @testmode("controlled_access")
     def test_multipart_copy(self):
         drs.copy_to_bucket(self.drs_url, "test_oneshot_object", multipart_threshold=1024 * 1024)
 
+    @testmode("controlled_access")
     def test_copy(self):
         with self.subTest("Test copy to local location"):
             filepath = "test_copy_object_{uuid4()}"
@@ -117,6 +120,32 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
         drs_url = "drs://dg.4503/273f3453-4d16-4ddd-8877-dbac958a4f4d"  # Amish cohort v4 VCF
         drs.extract_tar_gz(drs_url, "test_cohort_extract_{uuid4()}")
 
+    @testmode("workspace_access")
+    def test_arg_propagation(self):
+        resp_json = mock.MagicMock(return_value={
+            'googleServiceAccount': {'data': {'project_id': "foo"}},
+            'dos': {'data_object': {'urls': [{'url': 'gs://asdf/asdf'}]}}
+        })
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.copy"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gscio"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.tar_gz"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            with mock.patch("terra_notebook_utils.drs.enable_requester_pays") as enable_requester_pays:
+                with self.subTest("Copy to local"):
+                    drs.copy(self.drs_url, "some_bucketsome_key")
+                    enable_requester_pays.assert_called_once_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
+                with self.subTest("Copy to bucket"):
+                    enable_requester_pays.reset_mock()
+                    drs.copy(self.drs_url, "gs://some_bucket/some_key")
+                    enable_requester_pays.assert_called_once_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
+                with self.subTest("Extract tarball"):
+                    enable_requester_pays.reset_mock()
+                    drs.extract_tar_gz(self.drs_url, "some_pfx", "some_bucket")
+                    enable_requester_pays.assert_called_once_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsTARGZ(TestCaseSuppressWarnings):

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -186,6 +186,7 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
                 self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
                                drs_url=self.drs_url,
                                dst=tf.name,
+                               workspace=WORKSPACE_NAME,
                                google_billing_project=WORKSPACE_GOOGLE_PROJECT)
                 with open(tf.name, "rb") as fh:
                     data = fh.read()
@@ -196,6 +197,7 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
                            drs_url=self.drs_url,
                            dst=f"gs://{WORKSPACE_BUCKET}/{key}",
+                           workspace=WORKSPACE_NAME,
                            google_billing_project=WORKSPACE_GOOGLE_PROJECT)
             blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
             out = io.BytesIO()


### PR DESCRIPTION
This allows requester pays functionality to work with CLI commands.