### PR TITLE
Add info and credentials drs commands

### DIFF
--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -1,3 +1,4 @@
+import json
 import argparse
 
 from terra_notebook_utils import drs
@@ -19,7 +20,6 @@ drs_cli = dispatch.group("drs", help=drs.__doc__, arguments={
               "Note that DRS URLs also involve a GS request.")
     )
 })
-
 
 @drs_cli.command("copy", arguments={
     "drs_url": dict(type=str),
@@ -51,3 +51,30 @@ def drs_extract_tar_gz(args: argparse.Namespace):
     pfx = pfx or None
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
     drs.extract_tar_gz(args.drs_url, pfx, bucket, args.workspace, args.google_billing_project)
+
+@drs_cli.command("info", arguments={
+    "drs_url": dict(type=str),
+})
+def drs_copy(args: argparse.Namespace):
+    """
+    Get information about drs:// objects
+    """
+    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    info = drs.resolve_drs_info_for_gs_storage(args.drs_url, args.workspace, args.google_billing_project)
+    data = info._asdict()
+    data['url'] = f"gs://{info.bucket_name}/{info.key}"
+    del data['credentials']
+    del data['bucket_name']
+    del data['key']
+    print(json.dumps(data, indent=2))
+
+@drs_cli.command("credentials", arguments={
+    "drs_url": dict(type=str),
+})
+def drs_copy(args: argparse.Namespace):
+    """
+    Return the credentials needed to access a DRS url.
+    """
+    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    info = drs.resolve_drs_info_for_gs_storage(args.drs_url, args.workspace, args.google_billing_project)
+    print(json.dumps(info.credentials, indent=2))

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -55,7 +55,7 @@ def drs_extract_tar_gz(args: argparse.Namespace):
 @drs_cli.command("info", arguments={
     "drs_url": dict(type=str),
 })
-def drs_copy(args: argparse.Namespace):
+def drs_info(args: argparse.Namespace):
     """
     Get information about drs:// objects
     """
@@ -71,7 +71,7 @@ def drs_copy(args: argparse.Namespace):
 @drs_cli.command("credentials", arguments={
     "drs_url": dict(type=str),
 })
-def drs_copy(args: argparse.Namespace):
+def drs_credentials(args: argparse.Namespace):
     """
     Return the credentials needed to access a DRS url.
     """

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -17,7 +17,7 @@ import gs_chunked_io as gscio
 
 logger = logging.getLogger(__name__)
 
-DRSInfo = namedtuple("DRSInfo", "credentials bucket_name key name")
+DRSInfo = namedtuple("DRSInfo", "credentials bucket_name key name size updated")
 
 def _parse_gs_url(gs_url: str) -> typing.Tuple[str, str]:
     if gs_url.startswith(_GS_SCHEMA):
@@ -93,8 +93,12 @@ def resolve_drs_info_for_gs_storage(
         raise Exception(f"Unable to resolve GS url for {drs_url}")
 
     bucket_name, key = _parse_gs_url(data_url)
-    name = drs_info['dos']['data_object'].get("name")
-    return DRSInfo(credentials=credentials_data, bucket_name=bucket_name, key=key, name=name)
+    return DRSInfo(credentials=credentials_data,
+                   bucket_name=bucket_name,
+                   key=key,
+                   name=drs_info['dos']['data_object'].get("name"),
+                   size=drs_info['dos']['data_object'].get("size"),
+                   updated=drs_info['dos']['data_object'].get("updated"))
 
 def resolve_drs_for_gs_storage(
     drs_url: str,


### PR DESCRIPTION
Add two new drs cli commands:
  - `tnu drs info`: display file name, size, modification date, and gs url
  - `tnu drs credentials`: display the credentials needed to access the gs url

depends on #84 #85 
