### PR TITLE
Remove extraneous args from DRS commands

### DIFF
--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -5,7 +5,9 @@ from terra_notebook_utils import drs
 from terra_notebook_utils.cli import dispatch, Config
 
 
-drs_cli = dispatch.group("drs", help=drs.__doc__, arguments={
+drs_cli = dispatch.group("drs", help=drs.__doc__)
+
+workspace_args = {
     "--workspace": dict(
         type=str,
         default=None,
@@ -19,11 +21,12 @@ drs_cli = dispatch.group("drs", help=drs.__doc__, arguments={
               "If omitted, the CLI configured `workspace_google_project` will be used. "
               "Note that DRS URLs also involve a GS request.")
     )
-})
+}
 
 @drs_cli.command("copy", arguments={
     "drs_url": dict(type=str),
     "dst": dict(type=str, help="local file path, or Google Storage location if prefixed with 'gs://'"),
+    ** workspace_args,
 })
 def drs_copy(args: argparse.Namespace):
     """
@@ -39,6 +42,7 @@ def drs_copy(args: argparse.Namespace):
     "drs_url": dict(type=str),
     "dst_gs_url": dict(type=str, help=("Root of extracted archive. This must be a Google Storage location prefixed"
                                        "prefixed with 'gs://'")),
+    ** workspace_args,
 })
 def drs_extract_tar_gz(args: argparse.Namespace):
     """
@@ -59,8 +63,7 @@ def drs_info(args: argparse.Namespace):
     """
     Get information about drs:// objects
     """
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    info = drs.resolve_drs_info_for_gs_storage(args.drs_url, args.workspace, args.google_billing_project)
+    info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
     data = info._asdict()
     data['url'] = f"gs://{info.bucket_name}/{info.key}"
     del data['credentials']
@@ -75,6 +78,5 @@ def drs_credentials(args: argparse.Namespace):
     """
     Return the credentials needed to access a DRS url.
     """
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    info = drs.resolve_drs_info_for_gs_storage(args.drs_url, args.workspace, args.google_billing_project)
+    info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
     print(json.dumps(info.credentials, indent=2))


### PR DESCRIPTION
Remove `workspace` name and `google-billing-project` from DRS and CLI commands that do not need these parameters.