### PR TITLE
Add a tnu drs head bytes function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,24 @@ drs.copy("drs://my-drs-url", "gs://my-dst-bucket/my-dst-key")
 drs.copy("drs://my-drs-url", "local_filepath")
 ```
 
+Head drs object:
+```
+from terra_notebook_utils import drs
+first_ten_bytes_of_drs_file = drs.head("drs://my-drs-url", n=10)
+print(first_ten_bytes_of_drs_file)
+```
+
 #### CLI
 
 Copy drs object to local or bucket:
 ```
 tnu drs copy drs://my-drs-url gs://my-dst-bucket/my-dstkey
 tnu drs copy drs://my-drs-url local_filepath
+```
+
+Head drs object:
+```
+tnu drs head drs://my-drs-url
 ```
 
 ### The VCF API and CLI

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ drs.copy("drs://my-drs-url", "local_filepath")
 Head drs object:
 ```
 from terra_notebook_utils import drs
-first_ten_bytes_of_drs_file = drs.head("drs://my-drs-url", n=10)
-print(first_ten_bytes_of_drs_file)
+drs.head("drs://my-drs-url", num_bytes=10)
 ```
 
 #### CLI
@@ -100,7 +99,7 @@ tnu drs copy drs://my-drs-url local_filepath
 
 Head drs object:
 ```
-tnu drs head drs://my-drs-url
+tnu drs head drs://my-drs-url -c 10
 ```
 
 ### The VCF API and CLI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-storage>=1.31.0
+google-cloud-storage==1.31.0
 gs-chunked-io >= 0.4, < 0.5
 firecloud
 bgzip >= 0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-storage
+google-cloud-storage>=1.31.0
 gs-chunked-io >= 0.4, < 0.5
 firecloud
 bgzip >= 0.3.0

--- a/scrap.py
+++ b/scrap.py
@@ -1,0 +1,7 @@
+import traceback
+
+try:
+    assert 1 == 2
+except Exception as e:
+    traceback.print_exc()
+    print()

--- a/scrap.py
+++ b/scrap.py
@@ -1,7 +1,0 @@
-import traceback
-
-try:
-    assert 1 == 2
-except Exception as e:
-    traceback.print_exc()
-    print()

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -56,20 +56,27 @@ def drs_copy_batch(args: argparse.Namespace):
     drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.google_billing_project)
 
 @drs_cli.command("head", arguments={
-    "-n": dict(type=int, required=False, default=1, help="Return the first integer n bytes of a file (uncompressed)."),
+    "-c": dict(type=int, required=False, default=None,
+               help="Return the first integer n bytes of a file (uncompressed)."),
     "drs_url": dict(type=str),
     ** workspace_args,
 })
 def drs_head(args: argparse.Namespace):
     """
-    Fetch the first byte of a drs:// object to verify access.
+    Print the first bytes of a drs:// object.
 
     Example:
-        tnu drs check-accessible drs://crouching-drs-hidden-access
+        tnu drs head drs://crouching-drs-hidden-access
     """
+    # if the user specified nothing, only fetch the first byte
+    args.c = 1 if args.c is None else args.c
+    assert args.c > 0
+
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    result = drs.head(args.drs_url, args.n, args.workspace, args.google_billing_project)
-    print(result)
+    drs.head(args.drs_url,
+             num_bytes=args.c,
+             workspace_name=args.workspace,
+             google_billing_project=args.google_billing_project)
 
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -55,18 +55,20 @@ def drs_copy_batch(args: argparse.Namespace):
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
     drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.google_billing_project)
 
-@drs_cli.command("check-accessible", arguments={
+@drs_cli.command("head", arguments={
+    "-n": dict(type=int, required=False, default=1, help="Return the first integer n bytes of a file (uncompressed)."),
     "drs_url": dict(type=str),
     ** workspace_args,
 })
-def drs_check_accessible(args: argparse.Namespace):
+def drs_head(args: argparse.Namespace):
     """
-    Fetch the first byte of a drs:// object to verify access
-    example:
+    Fetch the first byte of a drs:// object to verify access.
+
+    Example:
         tnu drs check-accessible drs://crouching-drs-hidden-access
     """
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    result = drs.check_accessible(args.drs_url)
+    result = drs.head(args.drs_url, args.n, args.workspace, args.google_billing_project)
     print(result)
 
 @drs_cli.command("extract-tar-gz", arguments={

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -55,6 +55,20 @@ def drs_copy_batch(args: argparse.Namespace):
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
     drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.google_billing_project)
 
+@drs_cli.command("head-first-byte", arguments={
+    "drs_urls": dict(type=str, nargs="*", help="space separated list of drs:// URIs"),
+    ** workspace_args,
+})
+def drs_head_first_byte_batch(args: argparse.Namespace):
+    """
+    Fetch the first byte of several drs:// objects to verify access
+    example:
+        tnu drs head-first-byte drs://my-drs-1 drs://my-drs-2 drs://my-drs-3
+    """
+    assert 1 <= len(args.drs_urls)
+    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    print(drs.head_first_byte_batch(args.drs_urls))
+
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),
     "dst_gs_url": dict(type=str, help=("Root of extracted archive. This must be a Google Storage location prefixed"

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -57,7 +57,7 @@ def drs_copy_batch(args: argparse.Namespace):
 
 @drs_cli.command("head", arguments={
     "-c": dict(type=int, required=False, default=None,
-               help="Return the first integer n bytes of a file (uncompressed)."),
+               help="Return the first integer c bytes of a file (uncompressed)."),
     "--buffer": dict(type=int, required=False, default=MULTIPART_THRESHOLD,
                      help="Control the buffer size when fetching data."),
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -2,7 +2,7 @@ import json
 import argparse
 from typing import Any, Dict
 
-from terra_notebook_utils import drs
+from terra_notebook_utils import drs, MULTIPART_THRESHOLD
 from terra_notebook_utils.cli import dispatch, Config
 
 
@@ -58,6 +58,8 @@ def drs_copy_batch(args: argparse.Namespace):
 @drs_cli.command("head", arguments={
     "-c": dict(type=int, required=False, default=None,
                help="Return the first integer n bytes of a file (uncompressed)."),
+    "--buffer": dict(type=int, required=False, default=MULTIPART_THRESHOLD,
+                     help="Control the buffer size when fetching data."),
     "drs_url": dict(type=str),
     ** workspace_args,
 })
@@ -75,6 +77,7 @@ def drs_head(args: argparse.Namespace):
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
     drs.head(args.drs_url,
              num_bytes=args.c,
+             buffer=args.buffer,
              workspace_name=args.workspace,
              google_billing_project=args.google_billing_project)
 

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -66,8 +66,8 @@ def drs_check_accessible(args: argparse.Namespace):
         tnu drs check-accessible drs://crouching-drs-hidden-access
     """
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    drs.check_accessible(args.drs_url)
-    print('ok')
+    result = drs.check_accessible(args.drs_url)
+    print(result)
 
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -66,7 +66,7 @@ def drs_check_accessible(args: argparse.Namespace):
         tnu drs check-accessible drs://crouching-drs-hidden-access
     """
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    drs.check_accessible(args.drs_urls)
+    drs.check_accessible(args.drs_url)
     print('ok')
 
 @drs_cli.command("extract-tar-gz", arguments={

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -55,19 +55,19 @@ def drs_copy_batch(args: argparse.Namespace):
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
     drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.google_billing_project)
 
-@drs_cli.command("head-first-byte", arguments={
-    "drs_urls": dict(type=str, nargs="*", help="space separated list of drs:// URIs"),
+@drs_cli.command("check-accessible", arguments={
+    "drs_url": dict(type=str),
     ** workspace_args,
 })
-def drs_head_first_byte_batch(args: argparse.Namespace):
+def drs_check_accessible(args: argparse.Namespace):
     """
-    Fetch the first byte of several drs:// objects to verify access
+    Fetch the first byte of a drs:// object to verify access
     example:
-        tnu drs head-first-byte drs://my-drs-1 drs://my-drs-2 drs://my-drs-3
+        tnu drs check-accessible drs://crouching-drs-hidden-access
     """
-    assert 1 <= len(args.drs_urls)
     args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    print(drs.head_first_byte_batch(args.drs_urls))
+    drs.check_accessible(args.drs_urls)
+    print('ok')
 
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -158,11 +158,10 @@ def head(drs_url: str,
          workspace_name: Optional[str] = WORKSPACE_NAME,
          google_billing_project: Optional[str] = WORKSPACE_GOOGLE_PROJECT):
     """
-    Head a DRS object by line or byte.
+    Head a DRS object by byte.
 
     :param drs_url: A drs:// schema URL.
-    :param num_bytes: Number of bytes to print from the DRS object.  Cannot be used with num_lines.
-    :param num_lines: Number of lines to print from the DRS object.  Cannot be used with num_bytes.
+    :param num_bytes: Number of bytes to print from the DRS object.
     :param workspace_name: The name of the terra workspace.
     :param google_billing_project: The name of the terra google billing project.
     """

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -6,7 +6,6 @@ import re
 import json
 import logging
 import requests
-from google.cloud.exceptions import NotFound
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from collections import namedtuple

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -145,8 +145,8 @@ def head(drs_url: str,
     client, info = resolve_drs_for_gs_storage(drs_url)
     blob = client.bucket(info.bucket_name, user_project=google_billing_project).blob(info.key)
     try:
-        with gscio.Reader(blob) as handle:
-            sys.stdout.buffer.write(handle(num_bytes, buffer=buffer))
+        with gscio.Reader(blob, chunk_size=buffer) as handle:
+            sys.stdout.buffer.write(handle(num_bytes))
     except (NotFound, Forbidden):
         raise GSBlobInaccessible(f'The DRS URL: {drs_url}\n'
                                  f'Could not be accessed because of:\n'

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -138,6 +138,7 @@ def check_accessible(drs_url: str,
     try:
         # don't expand compressed files, to save time
         blob.download_as_string(start=0, end=1, raw_download=True)
+        return 'ok'
     except Exception as e:
         raise InaccessibleDrsUrlException(f'The DRS URL: {drs_url}\n'
                                           f'Could not be accessed because of:\n'

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -127,7 +127,7 @@ def copy_to_local(drs_url: str,
         logger.info(f"Downloading {drs_url} to {filepath}")
         blob.download_to_file(fh)
 
-def print_bytes(source: Optional[Callable], num_bytes: int, buffer: int = MULTIPART_THRESHOLD):
+def print_bytes(source: Callable, num_bytes: int, buffer: int = MULTIPART_THRESHOLD):
     """
     Print data from a file until a certain number of bytes is hit.
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -126,8 +126,8 @@ def copy_to_local(drs_url: str,
         blob.download_to_file(fh)
 
 def check_accessible(drs_url: str,
-                    workspace_name: Optional[str]=WORKSPACE_NAME,
-                    google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+                     workspace_name: Optional[str]=WORKSPACE_NAME,
+                     google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     """
     Check access to a DRS object by attempting to access its first byte of data.
     """

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -154,7 +154,7 @@ def print_bytes(blob, num_bytes: int, buffer: int = MULTIPART_THRESHOLD):
             end += buffer + 1
 
 def head(drs_url: str,
-         num_bytes: Optional[int],
+         num_bytes: int,
          workspace_name: Optional[str] = WORKSPACE_NAME,
          google_billing_project: Optional[str] = WORKSPACE_GOOGLE_PROJECT):
     """

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -142,19 +142,20 @@ def print_bytes(blob, num_bytes: int, buffer: int = MULTIPART_THRESHOLD):
     end = buffer
     while True:
         if num_bytes_left <= buffer:
-            print(str(blob.download_as_bytes(start=start, end=num_bytes), sys.stdout.encoding), end='')
+            sys.stdout.buffer.write(blob.download_as_bytes(start=start, end=num_bytes))
             return
         else:
             data = blob.download_as_bytes(start=start, end=end)
             if not data:
                 return
-            print(str(data, sys.stdout.encoding), end='')
+            sys.stdout.buffer.write(data)
             num_bytes_left -= buffer
             start += buffer + 1
             end += buffer + 1
 
 def head(drs_url: str,
          num_bytes: int,
+         buffer: int = MULTIPART_THRESHOLD,
          workspace_name: Optional[str] = WORKSPACE_NAME,
          google_billing_project: Optional[str] = WORKSPACE_GOOGLE_PROJECT):
     """
@@ -170,7 +171,7 @@ def head(drs_url: str,
     client, info = resolve_drs_for_gs_storage(drs_url)
     blob = client.bucket(info.bucket_name, user_project=google_billing_project).blob(info.key)
     try:
-        print_bytes(blob, num_bytes)
+        print_bytes(blob=blob, num_bytes=num_bytes, buffer=buffer)
     except (NotFound, Forbidden):
         raise GSBlobInaccessible(f'The DRS URL: {drs_url}\n'
                                  f'Could not be accessed because of:\n'

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -125,9 +125,10 @@ def copy_to_local(drs_url: str,
         logger.info(f"Downloading {drs_url} to {filepath}")
         blob.download_to_file(fh)
 
-def check_accessible(drs_url: str,
-                     workspace_name: Optional[str]=WORKSPACE_NAME,
-                     google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+def head(drs_url: str,
+         n: int = 1,
+         workspace_name: Optional[str]=WORKSPACE_NAME,
+         google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     """
     Check access to a DRS object by attempting to access its first byte of data.
     """
@@ -137,8 +138,7 @@ def check_accessible(drs_url: str,
     blob = client.bucket(info.bucket_name, user_project=google_billing_project).blob(info.key)
     try:
         # don't expand compressed files, to save time
-        blob.download_as_string(start=0, end=1, raw_download=True)
-        return 'ok'
+        return blob.download_as_bytes(start=0, end=n, raw_download=True)
     except Exception:
         raise InaccessibleDrsUrlException(f'The DRS URL: {drs_url}\n'
                                           f'Could not be accessed because of:\n'

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -139,7 +139,7 @@ def check_accessible(drs_url: str,
         # don't expand compressed files, to save time
         blob.download_as_string(start=0, end=1, raw_download=True)
         return 'ok'
-    except Exception as e:
+    except Exception:
         raise InaccessibleDrsUrlException(f'The DRS URL: {drs_url}\n'
                                           f'Could not be accessed because of:\n'
                                           f'{traceback.format_exc()}')

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -102,17 +102,13 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             drs.copy_to_local(self.drs_url, tf.name)
 
     @testmode("controlled_access")
-    def test_head_first_byte(self):
-        drs.head_first_byte(self.drs_url)
+    def test_check_accessible(self):
+        # should pass without Exception, if the DRS URL exists
+        drs.check_accessible(self.drs_url)
 
         with self.assertRaises(drs.InaccessibleDrsUrlException):
             fake_drs_url = 'drs://nothing'
-            drs.head_first_byte(fake_drs_url)
-
-    @testmode("controlled_access")
-    def test_head_first_byte_batch(self):
-        result = drs.check_accessible(iter([self.drs_url]))
-        self.assertEqual(result, 'All DRS URLs are okay!')
+            drs.check_accessible(fake_drs_url)
 
     @testmode("controlled_access")
     def test_oneshot_copy(self):

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -7,6 +7,7 @@ import unittest
 import glob
 import pytz
 import tempfile
+import contextlib
 from uuid import uuid4
 from random import randint
 from datetime import datetime
@@ -103,8 +104,14 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     @testmode("controlled_access")
     def test_head(self):
-        self.assertEqual(len(drs.head(self.drs_url)), 1)
-        self.assertEqual(len(drs.head(self.drs_url, n=10)), 10)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            drs.head(self.drs_url)
+            self.assertEqual(1, len(out.getvalue().strip()))
+
+        with contextlib.redirect_stdout(out):
+            drs.head(self.drs_url, num_bytes=10)
+            self.assertEqual(10, len(out.getvalue().strip()))
 
         with self.assertRaises(drs.InaccessibleDrsUrlException):
             fake_drs_url = 'drs://nothing'

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -103,8 +103,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     @testmode("controlled_access")
     def test_check_accessible(self):
-        # should pass without Exception, if the DRS URL exists
-        drs.check_accessible(self.drs_url)
+        self.assertEqual(drs.check_accessible(self.drs_url), 'ok')
 
         with self.assertRaises(drs.InaccessibleDrsUrlException):
             fake_drs_url = 'drs://nothing'

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -137,7 +137,7 @@ class TestTerraNotebookUtilsBytesLogic(TestCaseSuppressWarnings):
                 out = sys.stdout.read()
                 self.assertEqual('123456789\n123456789\n123456789', out.strip())
 
-            os.remove(tmp_file)
+        os.remove(tmp_file)
 
 
 class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -107,6 +107,11 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
         self.assertEqual(len(data), 1)
 
     @testmode("controlled_access")
+    def test_head_first_byte_batch(self):
+        result = drs.head_first_byte_batch(iter([self.drs_url]))
+        self.assertEqual(result, 'All DRS URLs are okay!')
+
+    @testmode("controlled_access")
     def test_oneshot_copy(self):
         drs.copy_to_bucket(self.drs_url, "test_oneshot_object")
 

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -105,13 +105,13 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
     def test_head_first_byte(self):
         drs.head_first_byte(self.drs_url)
 
-        fake_drs_url = 'drs://nothing'
-        e = drs.head_first_byte(fake_drs_url)
-        self.assertIsInstance(e, drs.InaccessibleDrsUrlException)
+        with self.assertRaises(drs.InaccessibleDrsUrlException):
+            fake_drs_url = 'drs://nothing'
+            drs.head_first_byte(fake_drs_url)
 
     @testmode("controlled_access")
     def test_head_first_byte_batch(self):
-        result = drs.head_first_byte_batch(iter([self.drs_url]))
+        result = drs.check_accessible(iter([self.drs_url]))
         self.assertEqual(result, 'All DRS URLs are okay!')
 
     @testmode("controlled_access")

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -103,8 +103,11 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     @testmode("controlled_access")
     def test_head_first_byte(self):
-        data = drs.head_first_byte(self.drs_url)
-        self.assertEqual(len(data), 1)
+        drs.head_first_byte(self.drs_url)
+
+        fake_drs_url = 'drs://nothing'
+        e = drs.head_first_byte(fake_drs_url)
+        self.assertIsInstance(e, drs.InaccessibleDrsUrlException)
 
     @testmode("controlled_access")
     def test_head_first_byte_batch(self):

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -156,14 +156,19 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     @testmode("controlled_access")
     def test_head(self):
-        out = io.StringIO()
-        with contextlib.redirect_stdout(out):
+        # Can't use io.BytesIO() with contextlib.redirect_stdout(out) here as it doesn't support
+        # sys.stdout.buffer so this workaround gets the bytes stream as stdout, just for testing
+        with encoded_bytes_stream():
             drs.head(self.drs_url)
-            self.assertEqual(1, len(out.getvalue().strip()))
+            sys.stdout.seek(0)
+            out = sys.stdout.read()
+            self.assertEqual(1, len(out.strip()))
 
-        with contextlib.redirect_stdout(out):
+        with encoded_bytes_stream():
             drs.head(self.drs_url, num_bytes=10)
-            self.assertEqual(10, len(out.getvalue().strip()))
+            sys.stdout.seek(0)
+            out = sys.stdout.read()
+            self.assertEqual(10, len(out.strip()))
 
         with self.assertRaises(drs.InaccessibleDrsUrlException):
             fake_drs_url = 'drs://nothing'

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -98,48 +98,6 @@ def encoded_bytes_stream():
     sys.stdout = old_stdout
 
 
-class TestTerraNotebookUtilsBytesLogic(TestCaseSuppressWarnings):
-    def test_fetch_bytes(self):
-        tmp_file = 'delete_me.txt'
-        with open(tmp_file, 'wb') as f:
-            f.write(b'123456789\n123456789\n123456789')
-
-        def get_bytes(start, end):
-            with open(tmp_file, 'rb') as f:
-                bytes_to_return = f.read()
-            return bytes_to_return[start:end]
-
-        for buffer in [1, 2, 9, 10, 1000, 1000000]:
-
-            # Can't use io.BytesIO() with contextlib.redirect_stdout(out) here as it doesn't support
-            # sys.stdout.buffer so this workaround gets the bytes stream as stdout, just for testing
-            with encoded_bytes_stream():
-                drs.print_bytes(source=get_bytes, num_bytes=9, buffer=buffer)
-                sys.stdout.seek(0)
-                out = sys.stdout.read()
-                self.assertEqual('123456789', out.strip())
-
-            with encoded_bytes_stream():
-                drs.print_bytes(source=get_bytes, num_bytes=19, buffer=buffer)
-                sys.stdout.seek(0)
-                out = sys.stdout.read()
-                self.assertEqual('123456789\n123456789', out.strip())
-
-            with encoded_bytes_stream():
-                drs.print_bytes(source=get_bytes, num_bytes=21, buffer=buffer)
-                sys.stdout.seek(0)
-                out = sys.stdout.read()
-                self.assertEqual('123456789\n123456789\n1', out.strip())
-
-            with encoded_bytes_stream():
-                drs.print_bytes(source=get_bytes, num_bytes=100, buffer=buffer)
-                sys.stdout.seek(0)
-                out = sys.stdout.read()
-                self.assertEqual('123456789\n123456789\n123456789', out.strip())
-
-        os.remove(tmp_file)
-
-
 class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
     drs_url = "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35"
 

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -102,12 +102,13 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             drs.copy_to_local(self.drs_url, tf.name)
 
     @testmode("controlled_access")
-    def test_check_accessible(self):
-        self.assertEqual(drs.check_accessible(self.drs_url), 'ok')
+    def test_head(self):
+        self.assertEqual(len(drs.head(self.drs_url)), 1)
+        self.assertEqual(len(drs.head(self.drs_url, n=10)), 10)
 
         with self.assertRaises(drs.InaccessibleDrsUrlException):
             fake_drs_url = 'drs://nothing'
-            drs.check_accessible(fake_drs_url)
+            drs.head(fake_drs_url)
 
     @testmode("controlled_access")
     def test_oneshot_copy(self):

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -102,6 +102,11 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             drs.copy_to_local(self.drs_url, tf.name)
 
     @testmode("controlled_access")
+    def test_head_first_byte(self):
+        data = drs.head_first_byte(self.drs_url)
+        self.assertEqual(len(data), 1)
+
+    @testmode("controlled_access")
     def test_oneshot_copy(self):
         drs.copy_to_bucket(self.drs_url, "test_oneshot_object")
 

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -208,11 +208,11 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
 
     def test_accessible(self):
         with self.subTest("test access on first byte of drs"):
-            # should run with no problems
-            self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
-                           drs_urls=self.drs_url,
-                           workspace=WORKSPACE_NAME,
-                           google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+            result = self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
+                                    drs_urls=self.drs_url,
+                                    workspace=WORKSPACE_NAME,
+                                    google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+            self.assertEqual(result, 'ok')
 
         with self.subTest("test access on first byte of drs raises on non-existent drs url"):
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -206,16 +206,17 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self.assertEqual(self.expected_crc32c, blob.crc32c)
             self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
+    def test_accessible(self):
         with self.subTest("test head first byte of drs"):
             # should run with no problems
-            self._test_cmd(terra_notebook_utils.cli.drs.drs_head_first_byte_batch,
+            self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
                            drs_urls=self.drs_url,
                            workspace=WORKSPACE_NAME,
                            google_billing_project=WORKSPACE_GOOGLE_PROJECT)
 
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
                 fake_drs_url = 'drs://nothing'
-                self._test_cmd(terra_notebook_utils.cli.drs.drs_head_first_byte_batch,
+                self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
                                drs_urls=fake_drs_url,
                                workspace=WORKSPACE_NAME,
                                google_billing_project=WORKSPACE_GOOGLE_PROJECT)

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -207,7 +207,7 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
     def test_head(self):
-        with self.subTest("Test access on first byte of drs"):
+        with self.subTest("Test heading a drs url."):
             result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
                                     drs_url=self.drs_url,
                                     workspace=WORKSPACE_NAME,
@@ -221,7 +221,16 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
                                     google_billing_project=WORKSPACE_GOOGLE_PROJECT)
             self.assertEqual(len(result), 10)
 
-        with self.subTest("test access on first byte of drs raises on non-existent drs url"):
+            for buffer in [1, 2, 10, 11]:
+                result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
+                                        drs_url=self.drs_url,
+                                        c=10,
+                                        buffer=buffer,
+                                        workspace=WORKSPACE_NAME,
+                                        google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+                self.assertEqual(len(result), 10)
+
+        with self.subTest("Test heading a non-existent drs url."):
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
                 fake_drs_url = 'drs://nothing'
                 self._test_cmd(terra_notebook_utils.cli.drs.drs_head,

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -99,7 +99,7 @@ class _CLITestCase(TestCaseSuppressWarnings):
                 Config.write()
                 args = argparse.Namespace(**dict(**self.common_kwargs, **kwargs))
                 out = io.StringIO()
-                with contextlib.redirect_stdout(out):
+                with redirect_stdout(out):
                     cmd(args)
                 return out.getvalue().strip()
 

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -99,7 +99,7 @@ class _CLITestCase(TestCaseSuppressWarnings):
                 Config.write()
                 args = argparse.Namespace(**dict(**self.common_kwargs, **kwargs))
                 out = io.StringIO()
-                with redirect_stdout(out):
+                with contextlib.redirect_stdout(out):
                     cmd(args)
                 return out.getvalue().strip()
 
@@ -206,17 +206,17 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self.assertEqual(self.expected_crc32c, blob.crc32c)
             self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
-    def test_accessible(self):
-        with self.subTest("test access on first byte of drs"):
+    def test_head(self):
+        with self.subTest("Test access on first byte of drs"):
             result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
-                                    drs_urls=self.drs_url,
+                                    drs_url=self.drs_url,
                                     workspace=WORKSPACE_NAME,
                                     google_billing_project=WORKSPACE_GOOGLE_PROJECT)
             self.assertEqual(len(result), 1)
 
             result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
-                                    drs_urls=self.drs_url,
-                                    n=10,
+                                    drs_url=self.drs_url,
+                                    c=10,
                                     workspace=WORKSPACE_NAME,
                                     google_billing_project=WORKSPACE_GOOGLE_PROJECT)
             self.assertEqual(len(result), 10)
@@ -225,7 +225,7 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
                 fake_drs_url = 'drs://nothing'
                 self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
-                               drs_urls=fake_drs_url,
+                               drs_url=fake_drs_url,
                                workspace=WORKSPACE_NAME,
                                google_billing_project=WORKSPACE_GOOGLE_PROJECT)
 

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -208,16 +208,23 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
 
     def test_accessible(self):
         with self.subTest("test access on first byte of drs"):
-            result = self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
+            result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
                                     drs_urls=self.drs_url,
                                     workspace=WORKSPACE_NAME,
                                     google_billing_project=WORKSPACE_GOOGLE_PROJECT)
-            self.assertEqual(result, 'ok')
+            self.assertEqual(len(result), 1)
+
+            result = self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
+                                    drs_urls=self.drs_url,
+                                    n=10,
+                                    workspace=WORKSPACE_NAME,
+                                    google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+            self.assertEqual(len(result), 10)
 
         with self.subTest("test access on first byte of drs raises on non-existent drs url"):
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
                 fake_drs_url = 'drs://nothing'
-                self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
+                self._test_cmd(terra_notebook_utils.cli.drs.drs_head,
                                drs_urls=fake_drs_url,
                                workspace=WORKSPACE_NAME,
                                google_billing_project=WORKSPACE_GOOGLE_PROJECT)

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -207,13 +207,14 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
     def test_accessible(self):
-        with self.subTest("test head first byte of drs"):
+        with self.subTest("test access on first byte of drs"):
             # should run with no problems
             self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,
                            drs_urls=self.drs_url,
                            workspace=WORKSPACE_NAME,
                            google_billing_project=WORKSPACE_GOOGLE_PROJECT)
 
+        with self.subTest("test access on first byte of drs raises on non-existent drs url"):
             with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
                 fake_drs_url = 'drs://nothing'
                 self._test_cmd(terra_notebook_utils.cli.drs.drs_check_accessible,

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -206,6 +206,20 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             self.assertEqual(self.expected_crc32c, blob.crc32c)
             self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
+        with self.subTest("test head first byte of drs"):
+            # should run with no problems
+            self._test_cmd(terra_notebook_utils.cli.drs.drs_head_first_byte_batch,
+                           drs_urls=self.drs_url,
+                           workspace=WORKSPACE_NAME,
+                           google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+
+            with self.assertRaises(terra_notebook_utils.drs.InaccessibleDrsUrlException):
+                fake_drs_url = 'drs://nothing'
+                self._test_cmd(terra_notebook_utils.cli.drs.drs_head_first_byte_batch,
+                               drs_urls=fake_drs_url,
+                               workspace=WORKSPACE_NAME,
+                               google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsCLI_Table(_CLITestCase):


### PR DESCRIPTION
See: https://ucsc-cgl.atlassian.net/browse/TLP-1535

@xbrianh 

I was worried if I just called this `head`, then people might expect to be able to read the first 10 characters/lines of a DRS object, so I renamed it `check_accessible` to better fit the use-case.  I could make this into an actual `head` function, but I'm worried that that would entail not using `raw_read`, which means decompressing on the Google side, so it would likely slow things down if we're only checking for accessibility.

Thoughts?