### PR TITLE
Make API load config as well.

### DIFF
--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -23,11 +23,11 @@ class Config:
     @classmethod
     def resolve(cls, override_workspace: Optional[str] = None, override_namespace: Optional[str] = None):
         workspace_name = (override_workspace or
-                          os.environ.get('WORKSPACE_NAME') or
-                          cls.info['workspace'])  # Should this be a higher priority?
+                          cls.info['workspace'] or
+                          os.environ.get('WORKSPACE_NAME'))
         namespace = (override_namespace or
+                     cls.info['workspace_google_project'] or
                      os.environ.get('GOOGLE_PROJECT') or  # This env var is set in Terra notebooks
-                     cls.info['workspace_google_project'] or  # Should this be a higher priority?
                      os.environ.get('GCP_PROJECT') or  # Useful for running outside of notebook
                      os.environ.get('GCLOUD_PROJECT'))  # Fallback
         if workspace_name and namespace is None:

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -22,22 +22,22 @@ class Config:
 
     @classmethod
     def resolve(cls, override_workspace: Optional[str] = None, override_namespace: Optional[str] = None):
-        workspace = (override_workspace or
-                     os.environ.get('WORKSPACE_NAME') or
-                     cls.info['workspace'])  # Should this be a higher priority?
+        workspace_name = (override_workspace or
+                          os.environ.get('WORKSPACE_NAME') or
+                          cls.info['workspace'])  # Should this be a higher priority?
         namespace = (override_namespace or
                      os.environ.get('GOOGLE_PROJECT') or  # This env var is set in Terra notebooks
                      cls.info['workspace_google_project'] or  # Should this be a higher priority?
                      os.environ.get('GCP_PROJECT') or  # Useful for running outside of notebook
                      os.environ.get('GCLOUD_PROJECT'))  # Fallback
-        if workspace and namespace is None:
+        if workspace_name and namespace is None:
             from terra_notebook_utils.workspace import get_workspace_namespace
-            namespace = get_workspace_namespace(workspace)
-        if not workspace:
+            namespace = get_workspace_namespace(workspace_name)
+        if not workspace_name:
             raise RuntimeError("This command requires a workspace. Either pass in a workspace with `--workspace`,"
                                " or configure a default workspace for the cli (see `tnu config --help`)."
                                " A default workspace may also be configured by setting the `WORKSPACE_NAME` env var")
-        return workspace, namespace
+        return workspace_name, namespace
 
 
 Config.load()

--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -1,43 +1,11 @@
 """
 Configure the CLI
 """
-import os
-import json
-from typing import Optional
-
 import cli_builder
 
-from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import Config
 
 
-class Config:
-    info = dict(workspace=None, workspace_google_project=None)
-    path = os.path.join(os.path.expanduser("~"), ".tnu_config")
-
-    @classmethod
-    def load(cls):
-        if not os.path.isfile(cls.path):
-            cls.write()
-        with open(cls.path) as fh:
-            cls.info = json.loads(fh.read())
-
-    @classmethod
-    def write(cls):
-        with open(cls.path, "w") as fh:
-            fh.write(json.dumps(cls.info, indent=2))
-
-    @classmethod
-    def resolve(cls, override_workspace: Optional[str], override_namespace: Optional[str]):
-        workspace = override_workspace or (cls.info['workspace'] or WORKSPACE_NAME)
-        namespace = override_namespace or (cls.info['workspace_google_project'] or WORKSPACE_GOOGLE_PROJECT)
-        if workspace and namespace is None:
-            from terra_notebook_utils.workspace import get_workspace_namespace
-            namespace = get_workspace_namespace(workspace)
-        if not workspace:
-            raise RuntimeError("This command requies a workspace. Either pass in a workspace with `--workspace`,"
-                               " or configure a default workspace for the cli (see `tnu config --help`)."
-                               " A default workspace may also be configued by setting the `WORKSPACE_NAME` env var")
-        return workspace, namespace
 Config.load()
 
 


### PR DESCRIPTION
Only the CLI was loading the config.  This makes it so that both the CLI and the API load the `~/.tnu_config` file.

I've also incorporated some of the exterior settings (fetching from env vars) that were done outside of config, inside of the config.
