### PR TITLE
Add support for martha_v3 [WA-320][WA-348]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ export TNU_TESTMODE?=workspace_access
 
 test: lint mypy tests
 
+dev_env_access_test:
+	$(MAKE) TNU_TESTMODE="dev_env_access" test
+
 all_test: 
 	$(MAKE) TNU_TESTMODE="workspace_access controlled_access" test
 
 controlled_access_test:
 	$(MAKE) TNU_TESTMODE="controlled_access" test
-
-dev_env_access_test:
-	$(MAKE) TNU_TESTMODE="dev_env_access" test
 
 lint:
 	flake8 $(MODULES) *.py

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ all_test:
 controlled_access_test:
 	$(MAKE) TNU_TESTMODE="controlled_access" test
 
+dev_env_access_test:
+	$(MAKE) TNU_TESTMODE="dev_env_access" test
+
 lint:
 	flake8 $(MODULES) *.py
 

--- a/README.md
+++ b/README.md
@@ -147,16 +147,17 @@ If you don't wish to run this within a docker image, skip to step 5.
 5. log in with your Google credentials using `gcloud auth application-default login`,
 6. install requirements with `pip install -r requirements.txt`
 7. set up the following environment variables, depending on what you will be using: 
-  - `export GOOGLE_PROJECT=[validProject]`
-  - `export WORKSPACE_NAME=[workspaceWithinProject]`
-  - `export TERRA_DEPLOYMENT_ENV=dev` 
-  - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]`
-  - `export GCLOUD_PROJECT=[validGoogleProject]` (set this if your DRS uri does not return Google SA)
-8. For Python API
+    - `export GOOGLE_PROJECT=[validProject]`
+    - `export WORKSPACE_NAME=[workspaceWithinProject]`
+    - `export TERRA_DEPLOYMENT_ENV=dev` 
+    - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]`
+    - `export GCLOUD_PROJECT=[validGoogleProject]` (set this if your DRS uri does not return Google SA)
+    - if you would like to run DRS methods against `martha_v2`, run `export MARTHA_URL_VERSION=martha_v2` (it is set to `martha_v3` by default)
+
+For Python API
   - run the python shell via `python`, and import any modules you wish to use. For example, `from terra_notebook_utils import drs`
-  For CLI
-  - run `pip install terra-notebook-utils`
-  - run `import terra_notebook_utils as tnu`
+  
+For CLI
   - run `scripts/tnu <command>`, for example `scripts/tnu drs copy drs://url/here local_path`
 
 Sample DRS urls used in tests:
@@ -171,23 +172,25 @@ To run tests, follow the same setup from Local Development till step 4. Make sur
 1. install requirements with `pip install -r requirements-dev.txt`
 2. set `export WORKSPACE_NAME=terra-notebook-utils-tests`
 
-Test Env: Prod 
+**Test Env: Prod**
+
 This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
 4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
 5. run in package root:
-  - `make test`: skips controlled and dev access tests
-  - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
+    - `make test`: skips controlled and dev access tests
+    - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
   
-Test Env: Dev (currently it has tests for DRS methods)
+**Test Env: Dev** (currently it has tests for DRS methods)
+
 This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to the above mentioned url)
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Dev account
 4. Set 
-  - `export GOOGLE_PROJECT=[googleProjectToBeBilled]`
-  - `export TERRA_DEPLOYMENT_ENV=dev`
-  - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
+    - `export GOOGLE_PROJECT=[googleProjectToBeBilled]`
+    - `export TERRA_DEPLOYMENT_ENV=dev`
+    - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
 5. run in package root:
-  - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
+    - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
 
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  

--- a/README.md
+++ b/README.md
@@ -196,6 +196,26 @@ This will run tests against Terra and Martha Prod (make sure you have proper acc
     - `make controlled_access_test`: runs tests marked as `controlled_access`
     - `make all_test`: runs all tests for Prod (controlled_access and workspace_access)
 
+## Release
+The commands mentioned in `common.mk` file are used for the release process. 
+Steps:
+- if you don't have a [PyPI](https://pypi.org/) account, please create one
+- you should be a collaborator in PyPI for Terra Notebook Utils. If you are not, please ask Brian Hannafious to add 
+you as a collaborator
+- run `make all_test` either from 
+    - inside the docker container created in Local Development or
+    - from repo root 
+  
+  (Make sure you have access to the DRS urls, workspaces and buckets as mentioned in Tests)
+  
+  Once tests pass, you can move to the release step
+- Release:
+    - For non-breaking API changes, use `make release_patch`
+    - For breaking API changes, use `make release_minor`
+    - For a major release, use `make release_major`
+
+If a release needs to be rolled back for some reason, please contact Brian Hannafious for help. 
+
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  
 Package distribution [PyPI](https://pypi.org/project/terra-notebook-utils)

--- a/README.md
+++ b/README.md
@@ -202,13 +202,10 @@ Steps:
 - if you don't have a [PyPI](https://pypi.org/) account, please create one
 - you should be a collaborator in PyPI for Terra Notebook Utils. If you are not, please ask Brian Hannafious to add 
 you as a collaborator
-- run `make all_test` either from 
-    - inside the docker container created in Local Development or
-    - from repo root 
-  
-  (Make sure you have access to the DRS urls, workspaces and buckets as mentioned in Tests)
-  
-  Once tests pass, you can move to the release step
+- follow the setup instructions as mentioned in `Tests` section above for env Prod. Make sure you have access 
+to the DRS urls, workspaces and buckets
+- run `make all_test` from inside the docker container created in `Local Development` section.
+Once tests pass, you can move to the release step
 - Release:
     - For non-breaking API changes, use `make release_patch`
     - For breaking API changes, use `make release_minor`

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If you don't wish to run this within a docker image, skip to step 5.
   - `export WORKSPACE_NAME=[workspaceWithinProject]`
   - `export TERRA_DEPLOYMENT_ENV=dev` 
   - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]`
-  - `export GCLOUD_PROJECT=[valid google project]` (set this if your DRS uri does not return Google SA)
+  - `export GCLOUD_PROJECT=[validGoogleProject]` (set this if your DRS uri does not return Google SA)
 8. For Python API
   - run the python shell via `python`, and import any modules you wish to use. For example, `from terra_notebook_utils import drs`
   For CLI
@@ -167,29 +167,27 @@ Make sure you are setting proper environment variables mentioned in step 7 for e
 
 
 ## Tests
-To run tests, follow the same setup from Local Development till step 4. Then,
-1. Your account must have access to the workspace `terra-notebook-utils-tests` 
-2. install requirements with `pip install -r requirements-dev.txt`
-3. Set `export WORKSPACE_NAME=terra-notebook-utils-tests`
+To run tests, follow the same setup from Local Development till step 4. Make sure your account has access to the workspace `terra-notebook-utils-tests` 
+1. install requirements with `pip install -r requirements-dev.txt`
+2. set `export WORKSPACE_NAME=terra-notebook-utils-tests`
 
 Test Env: Prod 
 This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
-4. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
-5. Set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
-6. run in package root:
+3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
+4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
+5. run in package root:
   - `make test`: skips controlled and dev access tests
   - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
   
 Test Env: Dev (currently it has tests for DRS methods)
-This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to this url)
-4. log in with your Google credentials using `gcloud auth application-default login` with your Terra Dev account
-5. Set 
-  - `export GOOGLE_PROJECT=[google project to be billed]`
+This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to the above mentioned url)
+3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Dev account
+4. Set 
+  - `export GOOGLE_PROJECT=[googleProjectToBeBilled]`
   - `export TERRA_DEPLOYMENT_ENV=dev`
   - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
-6. run in package root:
+5. run in package root:
   - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
-
 
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  

--- a/README.md
+++ b/README.md
@@ -172,16 +172,6 @@ To run tests, follow the same setup from Local Development till step 4. Make sur
 1. install requirements with `pip install -r requirements-dev.txt`
 2. set `export WORKSPACE_NAME=terra-notebook-utils-tests`
 
-**Test Env: Prod**
-
-This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
-
-3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
-4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
-5. run in package root:
-    - `make test`: skips controlled and dev access tests
-    - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
-  
 **Test Env: Dev** (currently it has tests for DRS methods)
 
 This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to the above mentioned url)
@@ -193,6 +183,18 @@ This will run tests against Terra and Martha Dev using Jade Dev DRS url (make su
     - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
 5. run in package root:
     - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
+
+
+**Test Env: Prod**
+
+This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
+
+3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
+4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
+5. run in package root:
+    - `make test`: skips controlled and dev access tests
+    - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
+    - `make mypy all_test`: runs all tests for Prod (controlled_access and workspace_access)
 
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For local development:
 Developing within a docker image is recommended, since that most closely models how users will use this. Additionally, there are some issues with installing the requirements.txt on mac.
 If you don't wish to run this within a docker image, skip to step 5.
 2. run `docker pull us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12`
-3. run the image from *one directory above* the root directory of this repo via `docker run -itd --entrypoint='/bin/bash' -v $PWD/terra-notebook-utils:/work -u root -e PIP_USER=false --name test-image terra-jupyter-python:0.0.12`
+3. run the image from *one directory above* the root directory of this repo via `docker run -itd --entrypoint='/bin/bash' -v $PWD/terra-notebook-utils:/work -u root -e PIP_USER=false --name test-image us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:0.0.12`
 4. Attach your terminal to the image via `docker exec -it test-image bash`, then navigate to the directory the code is mounted to via `cd /work`. Note that the above command ensures any changes you make to files in the repo will be updated in the image as well.
 5. log in with your Google credentials using `gcloud auth application-default login`,
 6. install requirements with `pip install -r requirements.txt`
@@ -151,18 +151,45 @@ If you don't wish to run this within a docker image, skip to step 5.
   - `export WORKSPACE_NAME=[workspaceWithinProject]`
   - `export TERRA_DEPLOYMENT_ENV=dev` 
   - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]`
-8. run the python shell via `python`, and import any modules you wish to use. For example, `from terra_notebook_utils import drs`
+  - `export GCLOUD_PROJECT=[valid google project]` (set this if your DRS uri does not return Google SA)
+8. For Python API
+  - run the python shell via `python`, and import any modules you wish to use. For example, `from terra_notebook_utils import drs`
+  For CLI
+  - run `pip install terra-notebook-utils`
+  - run `import terra_notebook_utils as tnu`
+  - run `scripts/tnu <command>`, for example `scripts/tnu drs copy drs://url/here local_path`
 
-A sample non-protected test DRS url that resolves to a small file in dev: `drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0`
+Sample DRS urls used in tests:
+(you would need to get access to these before successfully resolving it)
+  - `drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0`: non-protected test DRS url that resolves to a small file in dev
+  - `drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060`: Jade Dev test url
+Make sure you are setting proper environment variables mentioned in step 7 for each DRS url
 
 
 ## Tests
-To run tests,
-1. log in with your Google credentials using `gcloud auth application-default login`,
-2. Your account must have access to the workspace `terra-notebook-utils-tests` 
-3. Run `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod; export WORKSPACE_NAME=terra-notebook-utils-tests`
-4. install requirements with `pip install -r requirements-dev.txt`,
-5. run `make test` in the package root.
+To run tests, follow the same setup from Local Development till step 4. Then,
+1. Your account must have access to the workspace `terra-notebook-utils-tests` 
+2. install requirements with `pip install -r requirements-dev.txt`
+3. Set `export WORKSPACE_NAME=terra-notebook-utils-tests`
+
+Test Env: Prod 
+This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
+4. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
+5. Set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
+6. run in package root:
+  - `make test`: skips controlled and dev access tests
+  - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
+  
+Test Env: Dev (currently it has tests for DRS methods)
+This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to this url)
+4. log in with your Google credentials using `gcloud auth application-default login` with your Terra Dev account
+5. Set 
+  - `export GOOGLE_PROJECT=[google project to be billed]`
+  - `export TERRA_DEPLOYMENT_ENV=dev`
+  - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
+6. run in package root:
+  - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
+
 
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ To run tests, follow the same setup from Local Development till step 4. Make sur
 **Test Env: Prod**
 
 This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
+
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
 4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
 5. run in package root:
@@ -184,6 +185,7 @@ This will run tests against Terra and Martha Prod (make sure you have proper acc
 **Test Env: Dev** (currently it has tests for DRS methods)
 
 This will run tests against Terra and Martha Dev using Jade Dev DRS url (make sure your Terra Dev account has access to the above mentioned url)
+
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Dev account
 4. Set 
     - `export GOOGLE_PROJECT=[googleProjectToBeBilled]`

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This will run tests against Terra and Martha Dev using Jade Dev DRS url (make su
     - `export TERRA_DEPLOYMENT_ENV=dev`
     - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]` (or a bucket where you want to copy data resolved through DRS url)
 5. run in package root:
-    - `make mypy dev_env_access_test`: runs tests marked as `dev_env_access`
+    - `make dev_env_access_test`: runs tests marked as `dev_env_access`
 
 
 **Test Env: Prod**
@@ -193,8 +193,8 @@ This will run tests against Terra and Martha Prod (make sure you have proper acc
 4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod` 
 5. run in package root:
     - `make test`: skips controlled and dev access tests
-    - `make mypy controlled_access_test`: runs tests marked as `controlled_access`
-    - `make mypy all_test`: runs all tests for Prod (controlled_access and workspace_access)
+    - `make controlled_access_test`: runs tests marked as `controlled_access`
+    - `make all_test`: runs all tests for Prod (controlled_access and workspace_access)
 
 ## Links
 Project home page [GitHub](https://github.com/DataBiosphere/terra-notebook-utils)  

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For CLI
   - run `scripts/tnu <command>`, for example `scripts/tnu drs copy drs://url/here local_path`
 
 Sample DRS urls used in tests:
-(you would need to get access to these before successfully resolving it)
+(you would need to get access to these before successfully resolving them)
   - `drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0`: non-protected test DRS url that resolves to a small file in dev
   - `drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060`: Jade Dev test url
 Make sure you are setting proper environment variables mentioned in step 7 for each DRS url
@@ -202,7 +202,7 @@ Steps:
 - if you don't have a [PyPI](https://pypi.org/) account, please create one
 - you should be a collaborator in PyPI for Terra Notebook Utils. If you are not, please ask Brian Hannafious to add 
 you as a collaborator
-- follow the setup instructions as mentioned in `Tests` section above for env Prod. Make sure you have access 
+- follow the setup instructions as mentioned in `Tests` section above for env Prod; make sure you have access 
 to the DRS urls, workspaces and buckets
 - run `make all_test` from inside the docker container created in `Local Development` section.
 Once tests pass, you can move to the release step

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -3,6 +3,7 @@ import os
 WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
 WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra notebooks
 TERRA_DEPLOYMENT_ENV = os.environ.get('TERRA_DEPLOYMENT_ENV', 'prod')
+MARTHA_URL_VERSION = os.environ.get('MARTHA_URL_VERSION', 'martha_v3')
 
 if not WORKSPACE_GOOGLE_PROJECT:
     WORKSPACE_GOOGLE_PROJECT = os.environ.get('GCP_PROJECT')  # Useful for running outside of notebook
@@ -17,5 +18,7 @@ if WORKSPACE_BUCKET is not None and WORKSPACE_BUCKET.startswith(_GS_SCHEMA):
 
 MULTIPART_THRESHOLD = 1024 * 1024 * 32
 IO_CONCURRENCY = 3
+
+MARTHA_URL = f"https://us-central1-broad-dsde-{TERRA_DEPLOYMENT_ENV}.cloudfunctions.net/{MARTHA_URL_VERSION}"
 
 from terra_notebook_utils import drs, profile, table, vcf, workspace

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from terra_notebook_utils import drs, MULTIPART_THRESHOLD
 from terra_notebook_utils.cli import dispatch, Config
+from terra_notebook_utils.drs import DRSResolutionError
 
 
 drs_cli = dispatch.group("drs", help=drs.__doc__)
@@ -106,7 +107,13 @@ def drs_info(args: argparse.Namespace):
     """
     Get information about drs:// objects
     """
-    info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
+    try:
+        info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
+    except DRSResolutionError:
+        raise
+    except Exception:
+        raise
+
     data = info._asdict()
     data['url'] = f"gs://{info.bucket_name}/{info.key}"
     del data['credentials']
@@ -121,5 +128,11 @@ def drs_credentials(args: argparse.Namespace):
     """
     Return the credentials needed to access a DRS url.
     """
-    info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
+    try:
+        info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
+    except DRSResolutionError:
+        raise
+    except Exception:
+        raise
+
     print(json.dumps(info.credentials, indent=2))

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -92,9 +92,8 @@ def convert_martha_v2_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
     """
     Convert response from martha_v2 to DRSInfo
     """
-    credentials_data = extract_credentials_from_drs_response(drs_response)
-
     if 'data_object' in drs_response['dos']:
+        credentials_data = extract_credentials_from_drs_response(drs_response)
         data_object = drs_response['dos']['data_object']
 
         if 'urls' not in data_object:
@@ -116,12 +115,7 @@ def convert_martha_v2_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
                        size=data_object.get('size', None),
                        updated=data_object.get('updated', None))
     else:
-        return DRSInfo(credentials=credentials_data,
-                       bucket_name=None,
-                       key=None,
-                       name=None,
-                       size=None,
-                       updated=None)
+        raise Exception(f"No metadata was returned for DRS uri '{drs_url}'")
 
 def convert_martha_v3_response_to_DRSInfo(drs_url: str, drs_response: dict) -> DRSInfo:
     """
@@ -132,10 +126,13 @@ def convert_martha_v3_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
 
     credentials_data = extract_credentials_from_drs_response(drs_response)
 
+    # Related ticket links:
+    # WA-344: Return file name in martha_response (https://broadworkbench.atlassian.net/browse/WA-344)
+    # WA-348: Add this new file name in TNU (https://broadworkbench.atlassian.net/browse/WA-348)
     return DRSInfo(credentials=credentials_data,
                    bucket_name=drs_response.get('bucket', None),
                    key=drs_response.get('name', None),
-                   name=drs_response.get('name', None),
+                   name=None, # currently martha_v3 doesn't return the file name. This should be changed in WA-348.
                    size=drs_response.get('size', None),
                    updated=drs_response.get('timeUpdated', None))
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -100,12 +100,13 @@ def convert_martha_v2_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
         if 'urls' not in data_object:
             raise Exception(f"No GCS url found for DRS uri '{drs_url}'")
         else:
+            data_url = None
             for url_info in data_object['urls']:
                 if 'url' in url_info and url_info['url'].startswith(_GS_SCHEMA):
                     data_url = url_info['url']
                     break
-                else:
-                    raise Exception(f"No GCS url found for DRS uri '{drs_url}'")
+            if data_url is None:
+                raise Exception(f"No GCS url found for DRS uri '{drs_url}'")
 
         bucket_name, key = _parse_gs_url(data_url)
         return DRSInfo(credentials=credentials_data,

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -140,13 +140,10 @@ def convert_martha_v3_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
 
     credentials_data = extract_credentials_from_drs_response(drs_response)
 
-    # Related ticket links:
-    # WA-344: Return file name in martha_response (https://broadworkbench.atlassian.net/browse/WA-344)
-    # WA-348: Add this new file name in TNU (https://broadworkbench.atlassian.net/browse/WA-348)
     return DRSInfo(credentials=credentials_data,
                    bucket_name=drs_response.get('bucket'),
                    key=drs_response.get('name'),
-                   name=None,  # currently martha_v3 doesn't return the file name. This should be changed in WA-348.
+                   name=drs_response.get('fileName'),
                    size=drs_response.get('size'),
                    updated=drs_response.get('timeUpdated'))
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -132,7 +132,7 @@ def convert_martha_v3_response_to_DRSInfo(drs_url: str, drs_response: dict) -> D
     return DRSInfo(credentials=credentials_data,
                    bucket_name=drs_response.get('bucket', None),
                    key=drs_response.get('name', None),
-                   name=None, # currently martha_v3 doesn't return the file name. This should be changed in WA-348.
+                   name=None,  # currently martha_v3 doesn't return the file name. This should be changed in WA-348.
                    size=drs_response.get('size', None),
                    updated=drs_response.get('timeUpdated', None))
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -218,27 +218,26 @@ def head(drs_url: str,
     enable_requester_pays(workspace_name, google_billing_project)
     try:
         client, info = resolve_drs_for_gs_storage(drs_url)
-    except Exception as e:
-        # terra always returns a 502 for everything
-        if 'got 502' in e.__repr__():
+        blob = client.bucket(info.bucket_name, user_project=google_billing_project).blob(info.key)
+        try:
+            # sys.stdout.buffer is used outside of a python notebook since that's the standard non-lossy way
+            # to write/display bytes; sys.stdout.buffer is not available inside of a python notebook
+            # though, as sys.stdout is a ipykernel.iostream.OutStream object:
+            # https://github.com/ipython/ipykernel/blob/master/ipykernel/iostream.py#L265
+            # so we use bare sys.stdout and rely on the ipykernel method's lossy unicode stream
+            stdout_buffer = getattr(sys.stdout, 'buffer', sys.stdout)
+            with gscio.Reader(blob, chunk_size=buffer) as handle:
+                stdout_buffer.write(handle.read(num_bytes))
+
+        except (NotFound, Forbidden):
             raise GSBlobInaccessible(f'The DRS URL: {drs_url}\n'
                                      f'Could not be accessed because of:\n'
                                      f'{traceback.format_exc()}')
-    blob = client.bucket(info.bucket_name, user_project=google_billing_project).blob(info.key)
-    try:
-        # sys.stdout.buffer is used outside of a python notebook since that's the standard non-lossy way
-        # to write/display bytes; sys.stdout.buffer is not available inside of a python notebook
-        # though, as sys.stdout is a ipykernel.iostream.OutStream object:
-        # https://github.com/ipython/ipykernel/blob/master/ipykernel/iostream.py#L265
-        # so we use bare sys.stdout and rely on the ipykernel method's lossy unicode stream
-        stdout_buffer = getattr(sys.stdout, 'buffer', sys.stdout)
-        with gscio.Reader(blob, chunk_size=buffer) as handle:
-            stdout_buffer.write(handle.read(num_bytes))
-
-    except (NotFound, Forbidden):
-        raise GSBlobInaccessible(f'The DRS URL: {drs_url}\n'
-                                 f'Could not be accessed because of:\n'
+    except DRSResolutionError:
+        raise GSBlobInaccessible(f'The DRS URL: {drs_url}\n Could not be accessed because of:\n'
                                  f'{traceback.format_exc()}')
+    except Exception:
+        raise
 
 def copy_to_bucket(drs_url: str,
                    dst_key: str,

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,8 +1,8 @@
 import os
 
-os.environ['GCLOUD_PROJECT'] = "firecloud-cgl"
-os.environ['WORKSPACE_NAME'] = "terra-notebook-utils-tests"
-os.environ['WORKSPACE_BUCKET'] = "gs://fc-9169fcd1-92ce-4d60-9d2d-d19fd326ff10"
+os.environ['GCLOUD_PROJECT'] = os.environ.get('GCLOUD_PROJECT', "firecloud-cgl")
+os.environ['WORKSPACE_NAME'] = os.environ.get('WORKSPACE_NAME', "terra-notebook-utils-tests")
+os.environ['WORKSPACE_BUCKET'] = os.environ.get('WORKSPACE_BUCKET', "gs://fc-9169fcd1-92ce-4d60-9d2d-d19fd326ff10")
 
 cred_data = os.environ.get("TNU_GCP_SERVICE_ACCOUNT_CREDENTIALS_DATA")
 if cred_data:

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -355,7 +355,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
         drs_urls = {
             # 1631686 bytes # name property disapeard from DRS response :(
             # "NWD522743.b38.irc.v1.cram.crai": "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35",  # 1631686 bytes
-            "95cc4ae1-dee7-4266-8b97-77cf46d83d35": "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35",
+            "NWD522743.b38.irc.v1.cram.crai": "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35",
             "data_phs001237.v2.p1.c1.avro.gz": "drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655",  # 1115092 bytes
             "RootStudyConsentSet_phs001237.TOPMed_WGS_WHI.v2.p1.c1.HMB-IRB.tar.gz":
                 "drs://dg.4503/e9c2caf2-b2a1-446d-92eb-8d5389e99ee3",  # 332237 bytes

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -160,6 +160,9 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
                 'updated': "2020-04-27T15:56:09.696Z",
                 'urls': [
                     {
+                        'url': 's3://my_bucket/my_data'
+                    },
+                    {
                         'url': 'gs://bogus/my_data'
                     }
                 ],
@@ -197,7 +200,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             }
         }
     }
-    mock_martha_v2_response_withput_gs_uri = {
+    mock_martha_v2_response_without_gs_uri = {
         'dos': {
             'data_object': {
                 'checksums': [
@@ -354,7 +357,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             self.assertEqual(15601108255, actual_info.size)
             self.assertEqual('2020-04-27T15:56:09.696Z', actual_info.updated)
 
-    # test for when we get everything what we wanted in martha_v3 response
+    # test for when we get everything what we wanted in martha_v2 response
     def test_martha_v2_response(self):
         resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response)
         requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
@@ -415,7 +418,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     # test for when no GCS url is found in martha_v2 response. It should throw error
     def test_martha_v2_response_without_gs_uri(self):
-        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_withput_gs_uri)
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_without_gs_uri)
         requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
         from contextlib import ExitStack
         with ExitStack() as es:

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -345,13 +345,18 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
     @testmode("controlled_access")
     def test_copy_batch(self):
+        # Currently martha_v3 doesn't return the actual file name which was previously returned by
+        # 'dos.data_object.name' key. Hence in the tests the files are copied to location using the basename from DRS
+        # urls. The changes in this test should be reverted as part of WA-348
+        # (https://broadworkbench.atlassian.net/browse/WA-348) since the actual file name will be returned by 'fileName'
+        # key in martha_v3 once WA-344 (https://broadworkbench.atlassian.net/browse/WA-344) is done.
         drs_urls = {
             # 1631686 bytes # name property disapeard from DRS response :(
             # "NWD522743.b38.irc.v1.cram.crai": "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35",  # 1631686 bytes
             "95cc4ae1-dee7-4266-8b97-77cf46d83d35": "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35",
-
-            "data_phs001237.v2.p1.c1.avro.gz": "drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655",  # 1115092 bytes
-            "RootStudyConsentSet_phs001237.TOPMed_WGS_WHI.v2.p1.c1.HMB-IRB.tar.gz":
+            "26e11149-5deb-4cd7-a475-16997a825655":
+                "drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655",  # 1115092 bytes
+            "e9c2caf2-b2a1-446d-92eb-8d5389e99ee3":
                 "drs://dg.4503/e9c2caf2-b2a1-446d-92eb-8d5389e99ee3",  # 332237 bytes
 
             # "NWD961306.freeze5.v1.vcf.gz": "drs://dg.4503/6e73a376-f7fd-47ed-ac99-0567bb5a5993",  # 2679331445 bytes

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -91,6 +91,132 @@ class TestTerraNotebookUtilsTable(TestCaseSuppressWarnings):
 
 class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
     drs_url = "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35"
+    jade_dev_url = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_" \
+                   "c0e40912-8b14-43f6-9a2f-b278144d0060"
+
+    # martha_v3 responses
+    mock_jdr_response = {
+        'contentType': 'application/octet-stream',
+        'size': 15601108255,
+        'timeCreated': '2020-04-27T15:56:09.696Z',
+        'timeUpdated': '2020-04-27T15:56:09.696Z',
+        'bucket': 'broad-jade-dev-data-bucket',
+        'name': 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+        'gsUri':
+            'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+        'googleServiceAccount': None,
+        'hashes': {
+            'md5': '336ea55913bc261b72875bd259753046',
+            'sha256': 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
+            'crc32c': '8a366443'
+        }
+    }
+    mock_martha_v3_response_missing_fields = {
+        'contentType': 'application/octet-stream',
+        'bucket': 'broad-jade-dev-data-bucket',
+        'gsUri':
+            'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+        'googleServiceAccount': {
+            'data': {
+                'project_id': "foo"
+            }
+        },
+        'hashes': {
+            'md5': '336ea55913bc261b72875bd259753046',
+        }
+    }
+    mock_martha_v3_response_without_gs_uri = {
+        'contentType': 'application/octet-stream',
+        'bucket': 'broad-jade-dev-data-bucket',
+        'googleServiceAccount': {
+            'data': {
+                'project_id': "foo"
+            }
+        },
+        'hashes': {
+            'md5': '336ea55913bc261b72875bd259753046',
+        }
+    }
+
+    # martha_v2 responses
+    mock_martha_v2_response = {
+        'dos': {
+            'data_object': {
+                'aliases': [],
+                'checksums': [
+                    {
+                        'checksum': "8a366443",
+                        'type': "crc32c"
+                    }, {
+                        'checksum': "336ea55913bc261b72875bd259753046",
+                        'type': "md5"
+                    }
+                ],
+                'created': "2020-04-27T15:56:09.696Z",
+                'description': "",
+                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
+                'mime_type': "",
+                'size': 15601108255,
+                'updated': "2020-04-27T15:56:09.696Z",
+                'urls': [
+                    {
+                        'url': 'gs://bogus/my_data'
+                    }
+                ],
+                'version': "6d60cacf"
+            }
+        },
+        'googleServiceAccount': {
+            'data': {
+                'project_id': "foo"
+            }
+        }
+    }
+    mock_martha_v2_response_missing_fields = {
+        'dos': {
+            'data_object': {
+                'checksums': [
+                    {
+                        'checksum': "8a366443",
+                        'type': "crc32c"
+                    }, {
+                        'checksum': "336ea55913bc261b72875bd259753046",
+                        'type': "md5"
+                    }
+                ],
+                'created': "2020-04-27T15:56:09.696Z",
+                'description': "",
+                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
+                'mime_type': "",
+                'urls': [
+                    {
+                        'url': 'gs://bogus/my_data'
+                    }
+                ],
+                'version': "6d60cacf"
+            }
+        }
+    }
+    mock_martha_v2_response_withput_gs_uri = {
+        'dos': {
+            'data_object': {
+                'checksums': [
+                    {
+                        'checksum': "8a366443",
+                        'type': "crc32c"
+                    }, {
+                        'checksum': "336ea55913bc261b72875bd259753046",
+                        'type': "md5"
+                    }
+                ],
+                'created': "2020-04-27T15:56:09.696Z",
+                'description': "",
+                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
+                'mime_type': "",
+                'version': "6d60cacf"
+            }
+        }
+    }
 
     @testmode("controlled_access")
     def test_resolve_drs_for_google_storage(self):
@@ -210,6 +336,94 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
                     drs.extract_tar_gz(self.drs_url, "some_pfx", "some_bucket")
                     enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
 
+    # test for when we get everything what we wanted in martha_v3 response
+    def test_martha_v3_response(self):
+        resp_json = mock.MagicMock(return_value=self.mock_jdr_response)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            _, actual_info = drs.resolve_drs_for_gs_storage(self.jade_dev_url)
+            self.assertEqual(None, actual_info.credentials)
+            self.assertEqual('broad-jade-dev-data-bucket', actual_info.bucket_name)
+            self.assertEqual('fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+                             actual_info.key)
+            self.assertEqual('fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+                             actual_info.name)
+            self.assertEqual(15601108255, actual_info.size)
+            self.assertEqual('2020-04-27T15:56:09.696Z', actual_info.updated)
+
+    # test for when we get everything what we wanted in martha_v3 response
+    def test_martha_v2_response(self):
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            _, actual_info = drs.resolve_drs_for_gs_storage(self.drs_url)
+            self.assertEqual({'project_id': "foo"}, actual_info.credentials)
+            self.assertEqual('bogus', actual_info.bucket_name)
+            self.assertEqual('my_data', actual_info.key)
+            self.assertEqual(None, actual_info.name)
+            self.assertEqual(15601108255, actual_info.size)
+            self.assertEqual('2020-04-27T15:56:09.696Z', actual_info.updated)
+
+    # test for when some fields are missing in martha_v3 response
+    def test_martha_v3_response_with_missing_fields(self):
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v3_response_missing_fields)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            _, actual_info = drs.resolve_drs_for_gs_storage(self.jade_dev_url)
+            self.assertEqual({'project_id': "foo"}, actual_info.credentials)
+            self.assertEqual('broad-jade-dev-data-bucket', actual_info.bucket_name)
+            self.assertEqual(None, actual_info.key)
+            self.assertEqual(None, actual_info.name)
+            self.assertEqual(None, actual_info.size)
+            self.assertEqual(None, actual_info.updated)
+
+    # test for when some fields are missing in martha_v2 response
+    def test_martha_v2_response_with_missing_fields(self):
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_missing_fields)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            _, actual_info = drs.resolve_drs_for_gs_storage(self.drs_url)
+            self.assertEqual(None, actual_info.credentials)
+            self.assertEqual('bogus', actual_info.bucket_name)
+            self.assertEqual('my_data', actual_info.key)
+            self.assertEqual(None, actual_info.name)
+            self.assertEqual(None, actual_info.size)
+            self.assertEqual(None, actual_info.updated)
+
+    # test for when 'gsUrl' is missing in martha_v3 response. It should throw error
+    def test_martha_v3_response_without_gs_uri(self):
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v3_response_without_gs_uri)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            with self.assertRaisesRegex(Exception, f"No GCS url found for DRS uri '{self.jade_dev_url}'"):
+                drs.resolve_drs_for_gs_storage(self.jade_dev_url)
+
+    # test for when no GCS url is found in martha_v2 response. It should throw error
+    def test_martha_v2_response_without_gs_uri(self):
+        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_withput_gs_uri)
+        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
+        from contextlib import ExitStack
+        with ExitStack() as es:
+            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
+            es.enter_context(mock.patch("terra_notebook_utils.drs.requests", post=requests_post))
+            with self.assertRaisesRegex(Exception, f"No GCS url found for DRS uri '{self.drs_url}'"):
+                drs.resolve_drs_for_gs_storage(self.drs_url)
+
     def test_url_basename(self):
         with self.subTest("Should raise for invalid or missing schemas"):
             for broken_url in ["alsdf", "s:/asdf", "s//saldf"]:
@@ -238,6 +452,45 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
 
         with self.assertRaises(ValueError):
             drs._bucket_name_and_key(f"gs://{expected_bucket_name}/")
+
+
+# These tests will only run on `make mypy dev_env_access_test` command as they are testing DRS against Terra Dev env
+@testmode("dev_env_access")
+class TestTerraNotebookUtilsDRSInDev(TestCaseSuppressWarnings):
+    jade_dev_url = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-" \
+                   "2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060"
+
+    def test_resolve_drs_for_google_storage(self):
+        _, info = drs.resolve_drs_for_gs_storage(self.jade_dev_url)
+        self.assertEqual(info.bucket_name, "broad-jade-dev-data-bucket")
+        self.assertEqual(info.key, "ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060")
+        self.assertEqual(info.name, "ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060")
+        self.assertEqual(info.size, 62043448)
+
+    def test_head(self):
+        # Can't use io.BytesIO() with contextlib.redirect_stdout(out) here as it doesn't support
+        # sys.stdout.buffer so this workaround gets the bytes stream as stdout, just for testing
+        with encoded_bytes_stream():
+            drs.head(self.jade_dev_url)
+            sys.stdout.seek(0)
+            out = sys.stdout.read()
+            self.assertEqual(1, len(out))
+
+    def test_download(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            drs.copy_to_local(self.jade_dev_url, tf.name)
+
+    def test_copy_to_local(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            drs.copy(self.jade_dev_url, tf.name)
+
+    def test_multipart_copy(self):
+        with mock.patch("terra_notebook_utils.MULTIPART_THRESHOLD", 1024 * 1024):
+            drs.copy_to_bucket(self.jade_dev_url, "test_oneshot_object")
+
+    def test_copy_to_bucket(self):
+        key = f"gs://{WORKSPACE_BUCKET}/test_oneshot_object_{uuid4()}"
+        drs.copy_to_bucket(self.jade_dev_url, key)
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsTARGZ(TestCaseSuppressWarnings):

--- a/tests/test_terra_notebook_utils.py
+++ b/tests/test_terra_notebook_utils.py
@@ -160,6 +160,7 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
     mock_martha_v3_response_missing_fields = {
         'contentType': 'application/octet-stream',
         'bucket': 'broad-jade-dev-data-bucket',
+        'name': 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
         'gsUri':
             'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
         'googleServiceAccount': {
@@ -456,7 +457,8 @@ class TestTerraNotebookUtilsDRS(TestCaseSuppressWarnings):
             _, actual_info = drs.resolve_drs_for_gs_storage(self.jade_dev_url)
             self.assertEqual({'project_id': "foo"}, actual_info.credentials)
             self.assertEqual('broad-jade-dev-data-bucket', actual_info.bucket_name)
-            self.assertEqual(None, actual_info.key)
+            self.assertEqual('fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+                             actual_info.key)
             self.assertEqual(None, actual_info.name)
             self.assertEqual(None, actual_info.size)
             self.assertEqual(None, actual_info.updated)

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -258,7 +258,7 @@ class TestTerraNotebookUtilsCLI_DRSInDev(_CLITestCase):
 
     @testmode("dev_env_access")
     def test_copy(self):
-        with self.subTest("test local"):
+        with self.subTest("test copy to local path"):
             with NamedTemporaryFile() as tf:
                 self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
                                drs_url=self.jade_dev_url,
@@ -269,7 +269,7 @@ class TestTerraNotebookUtilsCLI_DRSInDev(_CLITestCase):
                     data = fh.read()
                 self.assertEqual(_crc32c(data), self.expected_crc32c)
 
-        with self.subTest("test gs"):
+        with self.subTest("test copy to gs bucket"):
             key = "test-drs-cli-object"
             self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
                            drs_url=self.jade_dev_url,

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -182,12 +182,13 @@ class TestTerraNotebookUtilsCLI_Profile(_CLITestCase):
         self._test_cmd(terra_notebook_utils.cli.profile.list_billing_projects)
 
 
+# These tests will only run on `make dev_env_access_test` command as they are testing DRS against Terra Dev env
+@testmode("dev_env_access")
 class TestTerraNotebookUtilsCLI_DRSInDev(_CLITestCase):
     jade_dev_url = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-" \
                    "2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060"
     expected_crc32c = "/VKJIw=="
 
-    @testmode("dev_env_access")
     def test_copy(self):
         with self.subTest("test copy to local path"):
             with NamedTemporaryFile() as tf:

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -182,6 +182,39 @@ class TestTerraNotebookUtilsCLI_Profile(_CLITestCase):
         self._test_cmd(terra_notebook_utils.cli.profile.list_billing_projects)
 
 
+class TestTerraNotebookUtilsCLI_DRSInDev(_CLITestCase):
+    jade_dev_url = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-" \
+                   "2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060"
+    expected_crc32c = "/VKJIw=="
+
+    @testmode("dev_env_access")
+    def test_copy(self):
+        with self.subTest("test copy to local path"):
+            with NamedTemporaryFile() as tf:
+                self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
+                               drs_url=self.jade_dev_url,
+                               dst=tf.name,
+                               workspace=WORKSPACE_NAME,
+                               google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+                with open(tf.name, "rb") as fh:
+                    data = fh.read()
+                self.assertEqual(_crc32c(data), self.expected_crc32c)
+
+        with self.subTest("test copy to gs bucket"):
+            key = "test-drs-cli-object"
+            self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
+                           drs_url=self.jade_dev_url,
+                           dst=f"gs://{WORKSPACE_BUCKET}/{key}",
+                           workspace=WORKSPACE_NAME,
+                           google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+            blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
+            out = io.BytesIO()
+            blob.download_to_file(out)
+            blob.reload()  # download_to_file causes the crc32c to change, for some reason. Reload blob to recover.
+            self.assertEqual(self.expected_crc32c, blob.crc32c)
+            self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
+
+
 @testmode("controlled_access")
 class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
     drs_url = "drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35"
@@ -250,38 +283,6 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             output = self._run_cmd(cmd)
             self.assertIn(b'GSBlobInaccessible', output)
 
-
-class TestTerraNotebookUtilsCLI_DRSInDev(_CLITestCase):
-    jade_dev_url = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-" \
-                   "2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060"
-    expected_crc32c = "/VKJIw=="
-
-    @testmode("dev_env_access")
-    def test_copy(self):
-        with self.subTest("test copy to local path"):
-            with NamedTemporaryFile() as tf:
-                self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
-                               drs_url=self.jade_dev_url,
-                               dst=tf.name,
-                               workspace=WORKSPACE_NAME,
-                               google_billing_project=WORKSPACE_GOOGLE_PROJECT)
-                with open(tf.name, "rb") as fh:
-                    data = fh.read()
-                self.assertEqual(_crc32c(data), self.expected_crc32c)
-
-        with self.subTest("test copy to gs bucket"):
-            key = "test-drs-cli-object"
-            self._test_cmd(terra_notebook_utils.cli.drs.drs_copy,
-                           drs_url=self.jade_dev_url,
-                           dst=f"gs://{WORKSPACE_BUCKET}/{key}",
-                           workspace=WORKSPACE_NAME,
-                           google_billing_project=WORKSPACE_GOOGLE_PROJECT)
-            blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
-            out = io.BytesIO()
-            blob.download_to_file(out)
-            blob.reload()  # download_to_file causes the crc32c to change, for some reason. Reload blob to recover.
-            self.assertEqual(self.expected_crc32c, blob.crc32c)
-            self.assertEqual(_crc32c(out.getvalue()), blob.crc32c)
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsCLI_Table(_CLITestCase):

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -283,8 +283,11 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
             with self.assertRaises(subprocess.CalledProcessError):
                 try:
                     self._run_cmd(cmd)
-                except subprocess.CalledProcessError:
-                    self.assertTrue('GSBlobInaccessible' in traceback.format_exc())
+                except subprocess.CalledProcessError as e:
+                    self.assertTrue(b'GSBlobInaccessible' in e.stderr)
+                    self.assertTrue(b'DRSResolutionError: Unexpected response while resolving DRS path. Expected '
+                                    b'status 200, got 500. Error: Received error while resolving DRS URL. getaddrinfo '
+                                    b'ENOTFOUND nothing' in e.stderr)
                     raise
 
 

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -275,14 +275,17 @@ class TestTerraNotebookUtilsCLI_DRS(_CLITestCase):
                 self.assertEqual(len(stdout), 10)
 
         with self.subTest("Test heading a non-existent drs url."):
-            # TODO: cli_builder swallows exit codes, so CLI failures always exit with "0"
-            # TODO: change cli_builder to not do this, then use "except subprocess.CalledProcessError as e:" here
             fake_drs_url = 'drs://nothing'
             cmd = [f'{pkg_root}/scripts/tnu', 'drs', 'head', fake_drs_url,
                    f'--workspace={WORKSPACE_NAME} ',
                    f'--google-billing-project={WORKSPACE_GOOGLE_PROJECT}']
-            output = self._run_cmd(cmd)
-            self.assertIn(b'GSBlobInaccessible', output)
+            try:
+                self._run_cmd(cmd)
+            except subprocess.CalledProcessError as e:
+                self.assertIn(b'GSBlobInaccessible', e.stderr)
+                self.assertIn(b'DRSResolutionError: Unexpected response while resolving DRS path. Expected status 200, '
+                              b'got 500. Error: Received error while resolving DRS URL. getaddrinfo ENOTFOUND nothing',
+                              e.stderr)
 
 
 @testmode("workspace_access")


### PR DESCRIPTION
This PR adds support for `martha_v3`. DRS methods will be able to ping v3 by default. If one would like to use `martha_v2` to resolve their DRS urls, they can override the default by running 
`export MARTHA_URL_VERSION=martha_v2`.

Martha repo: https://github.com/broadinstitute/martha
martha_v3 response format: https://github.com/broadinstitute/martha#martha-v3

Closes:
- https://broadworkbench.atlassian.net/browse/WA-320
- https://broadworkbench.atlassian.net/browse/WA-348