### PR TITLE
Bump cli-builder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ google-cloud-storage==1.31.2
 gs-chunked-io >= 0.5.1, < 0.6
 firecloud
 bgzip >= 0.3.5, < 0.4
-cli-builder
+cli-builder >= 0.1.5, < 0.2
 oauth2client


### PR DESCRIPTION
This causes the CLI to report error messages instead of stack traces.