### PR TITLE
Introduce an abbreviated `drs_info` method

### DIFF
--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -107,19 +107,8 @@ def drs_info(args: argparse.Namespace):
     """
     Get information about drs:// objects
     """
-    try:
-        info = drs.resolve_drs_info_for_gs_storage(args.drs_url)
-    except DRSResolutionError:
-        raise
-    except Exception:
-        raise
-
-    data = info._asdict()
-    data['url'] = f"gs://{info.bucket_name}/{info.key}"
-    del data['credentials']
-    del data['bucket_name']
-    del data['key']
-    print(json.dumps(data, indent=2))
+    info = drs.drs_info(args.drs_url)
+    print(json.dumps(info, indent=2))
 
 @drs_cli.command("credentials", arguments={
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -94,6 +94,15 @@ def fetch_drs_info(drs_url: str) -> dict:
 
     return resp_data
 
+def drs_info(drs_url: str) -> dict:
+    """
+    Return a curated subset of data from `fetch_drs_info`.
+    """
+    info = resolve_drs_info_for_gs_storage(drs_url)
+    out = dict(name=info.name, size=info.size, updated=info.updated)
+    out['url'] = f"gs://{info.bucket_name}/{info.key}"
+    return out
+
 def extract_credentials_from_drs_response(response: dict) -> Optional[dict]:
     if 'googleServiceAccount' not in response or response['googleServiceAccount'] is None:
         credentials_data = None

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -490,6 +490,18 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
         with self.assertRaises(ValueError):
             drs._bucket_name_and_key(f"gs://{expected_bucket_name}/")
 
+    @testmode("controlled_access")
+    def test_drs_info(self):
+        uri = "drs://dg.4503/3677c5b9-3c68-48a7-af1c-62056ba82d1d"
+        expected_info = dict(
+            name="phg001275.v1.TOPMed_WGS_MESA_v2.genotype-calls-vcf.WGS_markerset_grc38.c2.HMB-NPU.tar.gz",
+            size=183312787601,
+            updated="2019-12-26T20:20:39.396Z",
+            url=("gs://nih-nhlbi-topmed-released-phs001416-c2/"
+                 "phg001275.v1.TOPMed_WGS_MESA_v2.genotype-calls-vcf.WGS_markerset_grc38.c2.HMB-NPU.tar.gz")
+        )
+        self.assertEqual(drs.drs_info(uri), expected_info)
+
 def _list_tree(root) -> Generator[str, None, None]:
     for (dirpath, dirnames, filenames) in os.walk(root):
         for filename in filenames:


### PR DESCRIPTION
This returns a curated subset of data from `fetch_drs_info`.

depends on #217 
closes #205