### PR TITLE
Refactor for consistent `--workspace-namespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,23 +68,25 @@ tnu vcf -h
 ```
 
 ```
-# Show your available billing projects
-tnu profile list-billing-projects
+# Show your available workspace namespaces (also known as Google billing projects)
+tnu profile list-workspace-namespaces
 ```
 
 ### CLI Configuration
 
-Several CLI commands target a workspace or require a Google billing project. Defaults can be configured using the
+Several CLI commands target a workspace or require a workspace namespace. Defaults can be configured using the
 commands
 ```
 tnu config set-workspace my-workspace
-tnu config set-workspace-google-project my-billing-project
+tnu config set-workspace-google-project my-workspace-namespace
 ```
 
-Alternatively, workspace and billing project can be passed in to individual commands instead of, or as overrides to,
+Note that workspace namespace is the same as Google billing project.
+
+Alternatively, workspace and workspace namespace can be passed in to individual commands instead of, or as overrides to,
 the configured defaults. See command help, e.g. `tnu table get --help`, for usage information.
 
-Finally, workspace and billing project can be specified with the environment variables
+Finally, workspace and workspace namespace can be specified with the environment variables
 `WORKSPACE_NAME` and `GOOGLE_PROJECT`. These values are used with lowest precedence.
 
 ### The DRS API and CLI

--- a/terra_notebook_utils/cli/config.py
+++ b/terra_notebook_utils/cli/config.py
@@ -20,14 +20,14 @@ def set_config_workspace(args: argparse.Namespace):
     Config.info["workspace"] = args.workspace
     Config.write()
 
-@config_cli.command("set-workspace-google-project", arguments={
-    "billing_project": dict()
+@config_cli.command("set-workspace-namespace", arguments={
+    "workspace_namespace": dict(type=str)
 })
-def set_config_billing_project(args: argparse.Namespace):
+def set_config_workspace_namespace(args: argparse.Namespace):
     """
-    Set billing project for cli commands
+    Set workspace namespace for cli commands
     """
-    Config.info["workspace_google_project"] = args.billing_project
+    Config.info["workspace_namespace"] = args.workspace_namespace
     Config.write()
 
 @config_cli.command("print")

--- a/terra_notebook_utils/cli/drs.py
+++ b/terra_notebook_utils/cli/drs.py
@@ -15,12 +15,12 @@ workspace_args: Dict[str, Dict[str, Any]] = {
         default=None,
         help="workspace name. If not provided, the configured CLI workspace will be used"
     ),
-    "--google-billing-project": dict(
+    "--workspace-namespace": dict(
         type=str,
         required=False,
-        default=Config.info['workspace_google_project'],
+        default=Config.info['workspace_namespace'],
         help=("The billing project for GS requests. "
-              "If omitted, the CLI configured `workspace_google_project` will be used. "
+              "If omitted, the CLI configured `workspace_namespace` will be used. "
               "Note that DRS URLs also involve a GS request.")
     )
 }
@@ -37,8 +37,8 @@ def drs_copy(args: argparse.Namespace):
         tnu drs copy drs://my-drs-id /tmp/doom
         tnu drs copy drs://my-drs-id gs://my-cool-bucket/my-cool-bucket-key
     """
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    drs.copy(args.drs_url, args.dst, args.workspace, args.google_billing_project)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    drs.copy(args.drs_url, args.dst, args.workspace, args.workspace_namespace)
 
 @drs_cli.command("copy-batch", arguments={
     "drs_urls": dict(type=str, nargs="*", help="space separated list of drs:// URIs"),
@@ -53,8 +53,8 @@ def drs_copy_batch(args: argparse.Namespace):
         tnu drs copy drs://my-drs-1 drs://my-drs-2 drs://my-drs-3 --dst gs://my-cool-bucket/my-cool-folder
     """
     assert 1 <= len(args.drs_urls)
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.google_billing_project)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    drs.copy_batch(args.drs_urls, args.dst, args.workspace, args.workspace_namespace)
 
 @drs_cli.command("head", arguments={
     "drs_url": dict(type=str),
@@ -70,7 +70,7 @@ def drs_head(args: argparse.Namespace):
     Example:
         tnu drs head drs://crouching-drs-hidden-access
     """
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
     # TODO: cli_build doesn't seem to honor "required=False"
     if not getattr(args, 'buffer', None):
         setattr(args, 'buffer', MULTIPART_THRESHOLD)
@@ -80,7 +80,7 @@ def drs_head(args: argparse.Namespace):
              num_bytes=args.bytes,
              buffer=args.buffer,
              workspace_name=args.workspace,
-             google_billing_project=args.google_billing_project)
+             workspace_namespace=args.workspace_namespace)
 
 @drs_cli.command("extract-tar-gz", arguments={
     "drs_url": dict(type=str),
@@ -97,8 +97,8 @@ def drs_extract_tar_gz(args: argparse.Namespace):
     assert args.dst_gs_url.startswith("gs://")
     bucket, pfx = args.dst_gs_url[5:].split("/", 1)
     pfx = pfx or None
-    args.workspace, args.google_billing_project = Config.resolve(args.workspace, args.google_billing_project)
-    drs.extract_tar_gz(args.drs_url, pfx, bucket, args.workspace, args.google_billing_project)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    drs.extract_tar_gz(args.drs_url, pfx, bucket, args.workspace, args.workspace_namespace)
 
 @drs_cli.command("info", arguments={
     "drs_url": dict(type=str),

--- a/terra_notebook_utils/cli/profile.py
+++ b/terra_notebook_utils/cli/profile.py
@@ -8,9 +8,9 @@ from terra_notebook_utils.cli import dispatch
 profile_cli = dispatch.group("profile", help=profile.__doc__)
 
 
-@profile_cli.command("list-billing-projects")
-def list_billing_projects(args: argparse.Namespace):
+@profile_cli.command("list-workspace-namespaces")
+def list_workspace_namespaces(args: argparse.Namespace):
     """
-    Billing projects available to the current usuer
+    Workspace namespaces available to the current usuer
     """
-    print(json.dumps(profile.list_billing_projects(), indent=2))
+    print(json.dumps(profile.list_workspace_namespaces(), indent=2))

--- a/terra_notebook_utils/cli/table.py
+++ b/terra_notebook_utils/cli/table.py
@@ -13,10 +13,10 @@ table_cli = dispatch.group("table", help=table.__doc__, arguments={
         default=None,
         help="workspace name. If not provided, the configured CLI workspace will be used"
     ),
-    "--namespace": dict(
+    "--workspace-namespace": dict(
         type=str,
         default=None,
-        help=("workspace namespace (google billing project). If not provided, the configured CLI google billing "
+        help=("workspace namespace. If not provided, the configured CLI google billing "
               "project will be used.")
     ),
 })
@@ -27,9 +27,9 @@ def list_tables(args: argparse.Namespace):
     """
     List all tables, with column headers, in the workspace
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
     out = dict()
-    for t, attributes in table.list_tables(args.workspace, args.namespace):
+    for t, attributes in table.list_tables(args.workspace, args.workspace_namespace):
         out[t] = attributes
     print(json.dumps(out, indent=2))
 
@@ -40,8 +40,8 @@ def get_table(args: argparse.Namespace):
     """
     Get all rows
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
-    for e in table.list_entities(args.table, args.workspace, args.namespace):
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    for e in table.list_entities(args.table, args.workspace, args.workspace_namespace):
         data = e['attributes']
         data[f'{args.table}_id'] = e['name']
         print(json.dumps(data, indent=2))
@@ -54,8 +54,8 @@ def get_row(args: argparse.Namespace):
     """
     Get one row
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
-    e = table.get_row(args.table, args.id, args.workspace, args.namespace)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    e = table.get_row(args.table, args.id, args.workspace, args.workspace_namespace)
     data = e['attributes']
     data[f'{args.table}_id'] = e['name']
     print(json.dumps(data, indent=2))
@@ -68,8 +68,8 @@ def fetch_drs_url(args: argparse.Namespace):
     """
     Fetch the DRS URL associated with `--file-name` in `--table`.
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
-    print(table.fetch_drs_url(args.table, args.file_name, args.workspace, args.namespace))
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    print(table.fetch_drs_url(args.table, args.file_name, args.workspace, args.workspace_namespace))
 
 @table_cli.command("get-cell", arguments={
     "--table": dict(type=str, required=True, help="table name"),
@@ -80,8 +80,8 @@ def get_cell(args: argparse.Namespace):
     """
     Get cell value
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
-    for e in table.list_entities(args.table, args.workspace, args.namespace):
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
+    for e in table.list_entities(args.table, args.workspace, args.workspace_namespace):
         if args.id == e['name']:
             print(e['attributes'][args.column])
 
@@ -101,7 +101,7 @@ def put_row(args: argparse.Namespace):
     input_keys=test_vcfs/a.vcf.gz,test_vcfs/b.vcf.gz \\
     output_key=foo.vcf.gz
     """
-    args.workspace, args.namespace = Config.resolve(args.workspace, args.namespace)
+    args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
     headers = [f"{args.table}_id"]
     values = [args.id]
     for pair in args.data:
@@ -109,4 +109,4 @@ def put_row(args: argparse.Namespace):
         headers.append(key)
         values.append(val)
     tsv = "\t".join(headers) + os.linesep + "\t".join(values)
-    table.upload_entities(tsv, args.workspace, args.namespace)
+    table.upload_entities(tsv, args.workspace, args.workspace_namespace)

--- a/terra_notebook_utils/cli/vcf.py
+++ b/terra_notebook_utils/cli/vcf.py
@@ -11,10 +11,10 @@ vcf_cli = dispatch.group("vcf", help=vcf.__doc__, arguments={
     "path": dict(
         help="local path, gs://, or drs://"
     ),
-    "--google-billing-project": dict(
+    "--workspace-namespace": dict(
         type=str,
         required=False,
-        default=Config.info['workspace_google_project'],
+        default=Config.info['workspace_namespace'],
         help=("The billing project for GS requests. "
               "If omitted, the CLI configured `workspace_google_project` will be used. "
               "Note that DRS URLs also involve a GS request.")
@@ -27,8 +27,8 @@ def head(args: argparse.Namespace):
     """
     Output VCF header.
     """
-    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
-    blob = _get_blob(args.path, args.google_billing_project)
+    _, args.workspace_namespace = Config.resolve(None, args.workspace_namespace)
+    blob = _get_blob(args.path, args.workspace_namespace)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)
     else:
@@ -40,8 +40,8 @@ def samples(args: argparse.Namespace):
     """
     Output VCF samples.
     """
-    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
-    blob = _get_blob(args.path, args.google_billing_project)
+    _, args.workspace_namespace = Config.resolve(None, args.workspace_namespace)
+    blob = _get_blob(args.path, args.workspace_namespace)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)
     else:
@@ -53,8 +53,8 @@ def stats(args: argparse.Namespace):
     """
     Output VCF stats.
     """
-    _, args.google_billing_project = Config.resolve(None, args.google_billing_project)
-    blob = _get_blob(args.path, args.google_billing_project)
+    _, args.workspace_namespace = Config.resolve(None, args.workspace_namespace)
+    blob = _get_blob(args.path, args.workspace_namespace)
     if blob:
         info = vcf.VCFInfo.with_blob(blob)
         size = blob.size

--- a/terra_notebook_utils/cli/workspace.py
+++ b/terra_notebook_utils/cli/workspace.py
@@ -25,24 +25,24 @@ def list_workspaces(args: argparse.Namespace):
 
 @workspace_cli.command("get", arguments={
     "--workspace": dict(type=str, required=True, help="workspace name"),
-    "--namespace": dict(type=str, required=False, default=None, help="workspace namespace"),
+    "--workspace-namespace": dict(type=str, required=False, default=None, help="workspace namespace"),
 })
 def get_workspace(args: argparse.Namespace):
     """
     Get information about a workspace
     """
-    data = workspace.get_workspace(args.workspace, args.namespace)
+    data = workspace.get_workspace(args.workspace, args.workspace_namespace)
     print(json.dumps(data, indent=2))
 
 @workspace_cli.command("get-bucket", arguments={
     "--workspace": dict(type=str, required=False, default=Config.info['workspace'], help="workspace name"),
-    "--namespace": dict(type=str, required=False, default=None, help="workspace namespace"),
+    "--workspace-namespace": dict(type=str, required=False, default=None, help="workspace namespace"),
 })
 def get_workspace_bucket(args: argparse.Namespace):
     """
     Get workspace bucket
     """
-    data = workspace.get_workspace(args.workspace, args.namespace)
+    data = workspace.get_workspace(args.workspace, args.workspace_namespace)
     bucket_name = data.get('workspace', dict()).get('bucketName', None)
     print(bucket_name)
 

--- a/terra_notebook_utils/profile.py
+++ b/terra_notebook_utils/profile.py
@@ -4,7 +4,7 @@ Miscelenious user profile commands
 from firecloud import fiss
 
 
-def list_billing_projects() -> list:
+def list_workspace_namespaces() -> list:
     """
     Billing projects available to the current usuer
     """

--- a/terra_notebook_utils/vcf.py
+++ b/terra_notebook_utils/vcf.py
@@ -88,14 +88,14 @@ class VCFInfo:
                 return cls.with_gzip_fileobj(raw)
 
 def vcf_info(uri: str,
-             google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> VCFInfo:
+             workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> VCFInfo:
     if uri.startswith("drs://"):
         client, drs_info = drs.resolve_drs_for_gs_storage(uri)
-        blob = client.bucket(drs_info.bucket_name, user_project=google_billing_project).get_blob(drs_info.key)
+        blob = client.bucket(drs_info.bucket_name, user_project=workspace_namespace).get_blob(drs_info.key)
         return VCFInfo.with_blob(blob)
     elif uri.startswith("gs://"):
         bucket, key = uri[5:].split("/", 1)
-        blob = gs.get_client().bucket(bucket, user_project=google_billing_project).get_blob(key)
+        blob = gs.get_client().bucket(bucket, user_project=workspace_namespace).get_blob(key)
         return VCFInfo.with_blob(blob)
     elif uri.startswith("s3://"):
         raise ValueError("S3 URIs not supported")

--- a/terra_notebook_utils/workflows.py
+++ b/terra_notebook_utils/workflows.py
@@ -21,8 +21,8 @@ class TNUCostException(Exception):
     pass
 
 def list_submissions(workspace_name: Optional[str]=WORKSPACE_NAME,
-                     google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Generator[dict, None, None]:
-    resp = fiss.fapi.list_submissions(google_billing_project, workspace_name)
+                     workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Generator[dict, None, None]:
+    resp = fiss.fapi.list_submissions(workspace_namespace, workspace_name)
     resp.raise_for_status()
     for s in resp.json():
         yield s
@@ -30,11 +30,11 @@ def list_submissions(workspace_name: Optional[str]=WORKSPACE_NAME,
 @lru_cache()
 def get_submission(submission_id: str,
                    workspace_name: Optional[str]=WORKSPACE_NAME,
-                   google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
+                   workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
     """
     Get information about a submission, including member workflows
     """
-    resp = fiss.fapi.get_submission(google_billing_project, workspace_name, submission_id)
+    resp = fiss.fapi.get_submission(workspace_namespace, workspace_name, submission_id)
     resp.raise_for_status()
     return resp.json()
 
@@ -42,19 +42,19 @@ def get_submission(submission_id: str,
 def get_workflow(submission_id: str,
                  workflow_id: str,
                  workspace_name: Optional[str]=WORKSPACE_NAME,
-                 google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
+                 workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
     """
     Get information about a workflow
     """
-    resp = fiss.fapi.get_workflow_metadata(google_billing_project, workspace_name, submission_id, workflow_id)
+    resp = fiss.fapi.get_workflow_metadata(workspace_namespace, workspace_name, submission_id, workflow_id)
     resp.raise_for_status()
     return resp.json()
 
 def estimate_workflow_cost(submission_id: str,
                            workflow_id: str,
                            workspace_name: Optional[str]=WORKSPACE_NAME,
-                           google_billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
-    all_metadata = get_workflow(submission_id, workflow_id, workspace_name, google_billing_project)
+                           workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+    all_metadata = get_workflow(submission_id, workflow_id, workspace_name, workspace_namespace)
     machine_type: Optional[str]
     for workflow_name, workflow_metadata in all_metadata['calls'].items():
         for execution_metadata in workflow_metadata:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,7 +17,7 @@ from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
 class ConfigOverride:
     def __init__(self, workspace, namespace, path=None):
         self.old_workspace = Config.info['workspace']
-        self.old_namespace = Config.info['workspace_google_project']
+        self.old_namespace = Config.info['workspace_namespace']
         self.old_path = Config.path
         self.workspace = workspace
         self.namespace = namespace
@@ -25,12 +25,12 @@ class ConfigOverride:
 
     def __enter__(self):
         Config.info['workspace'] = self.workspace
-        Config.info['workspace_google_project'] = self.namespace
+        Config.info['workspace_namespace'] = self.namespace
         Config.path = self.path
 
     def __exit__(self, *args, **kwargs):
         Config.info['workspace'] = self.old_workspace
-        Config.info['workspace_google_project'] = self.old_namespace
+        Config.info['workspace_namespace'] = self.old_namespace
         Config.path = self.old_path
 
 class CLITestMixin:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -47,7 +47,7 @@ class TestTerraNotebookUtilsWorkflows(unittest.TestCase):
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsWorkflowsCLI(CLITestMixin, unittest.TestCase):
-    common_kwargs = dict(workspace=WORKSPACE_NAME, google_billing_project=WORKSPACE_GOOGLE_PROJECT)
+    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
 
     def test_list_submissions(self):
         with mock.patch("terra_notebook_utils.workflows.list_submissions"):


### PR DESCRIPTION
The Google billing project for a Terra workspace was previously
refered to in several ways:
  - google-billing-project
  - namespace
  - workspace-namespace
This refactors to use workspace-namespace throughout.

Note that, in Terra Jupyter notebook environments, the value of
workspace-namespace is set in the environment variable
WORKSPACE_GOOGLE_PROJECT.