### PR TITLE
Move DRS head stdout to CLI only.

### DIFF
--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -1,7 +1,5 @@
 import io
-import sys
 import warnings
-import contextlib
 
 from google.cloud.storage import Client
 
@@ -13,13 +11,6 @@ class SuppressWarningsMixin:
         # Suppress unclosed socket warnings
         warnings.simplefilter("ignore", ResourceWarning)
 
-@contextlib.contextmanager
-def encoded_bytes_stream():
-    old_stdout = sys.stdout
-    sys.stdout = io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
-    yield
-    sys.stdout.close()
-    sys.stdout = old_stdout
 
 def upload_data(uri: str, data: bytes):
     if uri.startswith("gs://"):

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -244,7 +244,7 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
         the_bytes = drs.head(drs_url)
         self.assertEqual(1, len(the_bytes))
 
-        drs.head(drs_url, num_bytes=10)
+        the_bytes = drs.head(drs_url, num_bytes=10)
         self.assertEqual(10, len(the_bytes))
 
         with self.assertRaises(drs.GSBlobInaccessible):

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -37,13 +37,8 @@ class TestTerraNotebookUtilsDRSInDev(SuppressWarningsMixin, unittest.TestCase):
         self.assertEqual(info.size, 62043448)
 
     def test_head(self):
-        # Can't use io.BytesIO() with contextlib.redirect_stdout(out) here as it doesn't support
-        # sys.stdout.buffer so this workaround gets the bytes stream as stdout, just for testing
-        with encoded_bytes_stream():
-            drs.head(self.jade_dev_url)
-            sys.stdout.seek(0)
-            out = sys.stdout.read()
-            self.assertEqual(1, len(out))
+        the_bytes = drs.head(self.jade_dev_url)
+        self.assertEqual(1, len(the_bytes))
 
         with self.assertRaises(drs.GSBlobInaccessible):
             fake_drs_url = 'drs://nothing'
@@ -246,19 +241,11 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
     @testmode("controlled_access")
     def test_head(self):
         drs_url = 'drs://dg.4503/828d82a1-e6cd-4a24-a593-f7e8025c7d71'
-        # Can't use io.BytesIO() with contextlib.redirect_stdout(out) here as it doesn't support
-        # sys.stdout.buffer so this workaround gets the bytes stream as stdout, just for testing
-        with encoded_bytes_stream():
-            drs.head(drs_url)
-            sys.stdout.seek(0)
-            out = sys.stdout.read()
-            self.assertEqual(1, len(out))
+        the_bytes = drs.head(drs_url)
+        self.assertEqual(1, len(the_bytes))
 
-        with encoded_bytes_stream():
-            drs.head(drs_url, num_bytes=10)
-            sys.stdout.seek(0)
-            out = sys.stdout.read()
-            self.assertEqual(10, len(out))
+        drs.head(drs_url, num_bytes=10)
+        self.assertEqual(10, len(the_bytes))
 
         with self.assertRaises(drs.GSBlobInaccessible):
             fake_drs_url = 'drs://nothing'

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -20,7 +20,7 @@ from terra_notebook_utils import WORKSPACE_GOOGLE_PROJECT, WORKSPACE_BUCKET, WOR
 from terra_notebook_utils import drs, gs, tar_gz, vcf
 from terra_notebook_utils.drs import DRSResolutionError
 from contextlib import ExitStack
-from tests.infra import SuppressWarningsMixin, encoded_bytes_stream
+from tests.infra import SuppressWarningsMixin
 
 
 # These tests will only run on `make dev_env_access_test` command as they are testing DRS against Terra Dev env

--- a/tests/test_terra_notebook_utils_cli.py
+++ b/tests/test_terra_notebook_utils_cli.py
@@ -33,7 +33,7 @@ import terra_notebook_utils.cli.workspace
 import terra_notebook_utils.cli.profile
 import terra_notebook_utils.cli.drs
 import terra_notebook_utils.cli.table
-from tests.infra import SuppressWarningsMixin, encoded_bytes_stream, upload_data
+from tests.infra import SuppressWarningsMixin, upload_data
 from tests.infra.partialize_vcf import partialize_vcf
 
 


### PR DESCRIPTION
This should make `tnu drs head` thread-safe.

@xbrianh Please re-run tests on your side to verify.

Example notebook is here: https://terra.biodatacatalyst.nhlbi.nih.gov/#workspaces/firecloud-cgl/terra-notebook-utils-tests/notebooks/launch/test-drs-head.ipynb?mode=edit

```
import logging
import threading
import time

from google.api_core.exceptions import Forbidden
from terra_notebook_utils.drs import GSBlobInaccessible
from terra_notebook_utils import drs


logging.basicConfig(level=logging.INFO)
log = logging.getLogger(__name__)


def determine_drs_access(drs_url):
    try:
        drs.head(drs_url)
        log.info(f"SUCCESS  : {drs_url}")
    except GSBlobInaccessible:
        log.info(f"NO ACCESS: {drs_url}")


def main():
    threads = list()
    for drs_url in ('drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35',
                    'drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655',
                    'drs://dg.4503/e9c2caf2-b2a1-446d-92eb-8d5389e99ee3'):
        x = threading.Thread(target=determine_drs_access, args=(drs_url,))
        threads.append(x)
        x.start()

    for index, thread in enumerate(threads):
        thread.join()

        
if __name__ == "__main__":
    main()
```

```
2020-11-17 03:37:30::INFO  Resolving DRS uri 'drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35' through 'https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3'.
2020-11-17 03:37:30::INFO  Resolving DRS uri 'drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655' through 'https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3'.
2020-11-17 03:37:30::INFO  Resolving DRS uri 'drs://dg.4503/e9c2caf2-b2a1-446d-92eb-8d5389e99ee3' through 'https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3'.
2020-11-17 03:37:31::INFO  NO ACCESS: drs://dg.4503/26e11149-5deb-4cd7-a475-16997a825655
2020-11-17 03:37:31::INFO  NO ACCESS: drs://dg.4503/e9c2caf2-b2a1-446d-92eb-8d5389e99ee3
2020-11-17 03:37:31::INFO  SUCCESS  : drs://dg.4503/95cc4ae1-dee7-4266-8b97-77cf46d83d35
```