### PR TITLE
Give name of task when estimating costs

### DIFF
--- a/terra_notebook_utils/workflows.py
+++ b/terra_notebook_utils/workflows.py
@@ -68,7 +68,11 @@ def estimate_workflow_cost(submission_id: str,
                                                       memory_gb,
                                                       runtime_hours,
                                                       _parse_preemptible(execution_metadata))
-                yield dict(task_name=task_name, cost=cost, number_of_cpus=cpus, memory=memory_gb, duration=runtime_hours)
+                yield dict(task_name=task_name,
+                           cost=cost,
+                           number_of_cpus=cpus,
+                           memory=memory_gb,
+                           duration=runtime_hours)
             except TNUCostException as exc:
                 logger.warning(f"Unable to estimate costs for workflow {workflow_id}: "
                                f"{exc.args[0]}")

--- a/terra_notebook_utils/workflows.py
+++ b/terra_notebook_utils/workflows.py
@@ -59,6 +59,7 @@ def estimate_workflow_cost(submission_id: str,
     for workflow_name, workflow_metadata in all_metadata['calls'].items():
         for execution_metadata in workflow_metadata:
             try:
+                task_name = workflow_name.split(".")[1]
                 cpus, memory_mb = _parse_machine_type(execution_metadata)
                 memory_gb = int(memory_mb / 1024)
                 runtime_hours = _parse_runtime_seconds(execution_metadata)
@@ -67,7 +68,7 @@ def estimate_workflow_cost(submission_id: str,
                                                       memory_gb,
                                                       runtime_hours,
                                                       _parse_preemptible(execution_metadata))
-                yield dict(cost=cost, number_of_cpus=cpus, memory=memory_gb, duration=runtime_hours)
+                yield dict(task_name=task_name, cost=cost, number_of_cpus=cpus, memory=memory_gb, duration=runtime_hours)
             except TNUCostException as exc:
                 logger.warning(f"Unable to estimate costs for workflow {workflow_id}: "
                                f"{exc.args[0]}")


### PR DESCRIPTION
In the cost estimator notebook, which relies on TNU, each task is given a row, but it is not clear which row corresponds to which task unless the user has unique values for memory and CPU for each task. By default, the UM aligner has 6 GB of memory and 1 CPU for both the pre and post align tasks, meaning users can only differenciate them by cross checking against the workflow execution time ([which is sometimes inaccurate](https://support.terra.bio/hc/en-us/community/posts/360074917112-Terra-sometimes-misreports-workflow-times)) in another part of Terra's UI.

Ideally this would be in order that tasks are performed, but I think fiss just spits them out alpabetically.

When these edits are run in the workflow cost estimator, the table now looks like this: 
<img width="635" alt="tnu_edits_results" src="https://user-images.githubusercontent.com/27784612/101836374-227c4c00-3af2-11eb-836c-37d11228de87.png">
