### PR TITLE
Yield part sizes from 'download' and 'copy_from'

### DIFF
--- a/terra_notebook_utils/blobstore/__init__.py
+++ b/terra_notebook_utils/blobstore/__init__.py
@@ -32,12 +32,19 @@ class Blob:
     def delete(self):
         raise NotImplementedError()
 
-    def copy_from(self, src_blob: Any) -> Generator[int, None, None]:
+    def copy_from_iter(self, src_blob: Any) -> Generator[int, None, None]:
         """Intra-cloud copy. This yields the size of parts copied, and must be iterated"""
         raise NotImplementedError()
 
-    def download(self, path: str) -> Generator[int, None, None]:
+    def copy_from(self, src_blob: Any) -> Generator[int, None, None]:
+        """Intra-cloud copy."""
+        raise NotImplementedError()
+
+    def download_iter(self, path: str) -> Generator[int, None, None]:
         """This yields the size of parts downloaded, and must be iterated"""
+        raise NotImplementedError()
+
+    def download(self, path: str) -> Generator[int, None, None]:
         raise NotImplementedError()
 
     def exists(self) -> bool:

--- a/terra_notebook_utils/blobstore/__init__.py
+++ b/terra_notebook_utils/blobstore/__init__.py
@@ -32,11 +32,12 @@ class Blob:
     def delete(self):
         raise NotImplementedError()
 
-    def copy_from(self, src_blob: Any):
-        """Intra-cloud copy."""
+    def copy_from(self, src_blob: Any) -> Generator[int, None, None]:
+        """Intra-cloud copy. This yields the size of parts copied, and must be iterated"""
         raise NotImplementedError()
 
-    def download(self, path: str):
+    def download(self, path: str) -> Generator[int, None, None]:
+        """This yields the size of parts downloaded, and must be iterated"""
         raise NotImplementedError()
 
     def exists(self) -> bool:

--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -25,7 +25,7 @@ def _download(src_blob: AnyBlob, dst_blob: LocalBlob):
     if dirname:
         os.makedirs(dirname, exist_ok=True)
     # The download methods for each Blob is expected to compute checksums
-    for part_size in src_blob.download(dst_blob.url):
+    for part_size in src_blob.download_iter(dst_blob.url):
         pass
 
 def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
@@ -35,7 +35,7 @@ def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
     # compute the destination S3Etag on the fly.
     logger.debug(f"Starting intra-cloud {src_blob.url} to {dst_blob.url}")
     assert isinstance(src_blob, type(dst_blob))
-    for part_size in dst_blob.copy_from(src_blob):  # type: ignore
+    for part_size in dst_blob.copy_from_iter(src_blob):  # type: ignore
         pass
     if src_blob.cloud_native_checksum() != dst_blob.cloud_native_checksum():
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")

--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -25,7 +25,8 @@ def _download(src_blob: AnyBlob, dst_blob: LocalBlob):
     if dirname:
         os.makedirs(dirname, exist_ok=True)
     # The download methods for each Blob is expected to compute checksums
-    src_blob.download(dst_blob.url)
+    for part_size in src_blob.download(dst_blob.url):
+        pass
 
 def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
     # In general it is not necesary to compute checksums for intra cloud copies. The Storage services will do that for
@@ -34,7 +35,8 @@ def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
     # compute the destination S3Etag on the fly.
     logger.debug(f"Starting intra-cloud {src_blob.url} to {dst_blob.url}")
     assert isinstance(src_blob, type(dst_blob))
-    dst_blob.copy_from(src_blob)  # type: ignore
+    for part_size in dst_blob.copy_from(src_blob):  # type: ignore
+        pass
     if src_blob.cloud_native_checksum() != dst_blob.cloud_native_checksum():
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")
         raise BlobstoreChecksumError()

--- a/terra_notebook_utils/blobstore/local.py
+++ b/terra_notebook_utils/blobstore/local.py
@@ -85,7 +85,7 @@ class LocalBlob(blobstore.Blob):
         os.remove(self._path)
 
     @catch_blob_not_found_generator
-    def copy_from(self, src_blob: "LocalBlob") -> Generator[int, None, None]:
+    def copy_from_iter(self, src_blob: "LocalBlob") -> Generator[int, None, None]:
         """
         Intra-cloud copy
         """
@@ -94,12 +94,20 @@ class LocalBlob(blobstore.Blob):
             shutil.copyfile(src_blob._path, self._path)
         yield self.size()
 
-    def download(self, target: str) -> Generator[int, None, None]:
+    def copy_from(self, src_blob: "LocalBlob"):
+        for part in self.copy_from_iter(src_blob):
+            pass
+
+    def download_iter(self, target: str) -> Generator[int, None, None]:
         if not os.path.isfile(self._path):
             raise blobstore.BlobNotFoundError(f"Could not find {self.url}")
         if self._path != target:
             shutil.copyfile(self._path, target)
         yield self.size()
+
+    def download(self, target: str):
+        for _ in self.download_iter(target):
+            pass
 
     def exists(self) -> bool:
         if os.path.isdir(self._path):

--- a/terra_notebook_utils/blobstore/local.py
+++ b/terra_notebook_utils/blobstore/local.py
@@ -18,6 +18,16 @@ def catch_blob_not_found(func):
             raise blobstore.BlobNotFoundError(f"Could not find {self.url}") from ex
     return wrapper
 
+def catch_blob_not_found_generator(generator):
+    @wraps(generator)
+    def wrapper(self, *args, **kwargs):
+        try:
+            for item in generator(self, *args, **kwargs):
+                yield item
+        except FileNotFoundError as ex:
+            raise blobstore.BlobNotFoundError(f"Could not find {self.url}") from ex
+    return wrapper
+
 class LocalBlobStore(blobstore.BlobStore):
     chunk_size = default_chunk_size
 
@@ -74,20 +84,22 @@ class LocalBlob(blobstore.Blob):
     def delete(self):
         os.remove(self._path)
 
-    @catch_blob_not_found
-    def copy_from(self, src_blob: "LocalBlob"):
+    @catch_blob_not_found_generator
+    def copy_from(self, src_blob: "LocalBlob") -> Generator[int, None, None]:
         """
         Intra-cloud copy
         """
         assert isinstance(src_blob, type(self))
         if self.url != src_blob.url:
             shutil.copyfile(src_blob._path, self._path)
+        yield self.size()
 
-    def download(self, target: str):
+    def download(self, target: str) -> Generator[int, None, None]:
         if not os.path.isfile(self._path):
             raise blobstore.BlobNotFoundError(f"Could not find {self.url}")
         if self._path != target:
             shutil.copyfile(self._path, target)
+        yield self.size()
 
     def exists(self) -> bool:
         if os.path.isdir(self._path):

--- a/terra_notebook_utils/blobstore/url.py
+++ b/terra_notebook_utils/blobstore/url.py
@@ -61,7 +61,7 @@ class URLBlob(blobstore.Blob):
         return URLRawReader(self.url)
 
     @catch_blob_not_found_generator
-    def download(self, path: str) -> Generator[int, None, None]:
+    def download_iter(self, path: str) -> Generator[int, None, None]:
         checksums = http.checksums(self.url)
         if 'gs_crc32c' in checksums:
             cs = checksum.GETMChecksum(checksums['gs_crc32c'], "gs_crc32c")
@@ -85,6 +85,10 @@ class URLBlob(blobstore.Blob):
                     fh.write(part.data)
                     yield len(part.data)
             assert cs.matches(), "Checksum failed!"
+
+    def download(self, path: str):
+        for _ in self.download_iter(path):
+            pass
 
     @catch_blob_not_found
     def size(self) -> int:

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -129,11 +129,13 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             for src_blob in (test_data.oneshot_blob(bs), test_data.multipart_blob(bs)):
                 with self.subTest(src_key=src_blob.key, dst_key=dst_key, blobstore=bs):
                     dst_blob = bs.blob(dst_key)
-                    dst_blob.copy_from(src_blob)
+                    for part_size in dst_blob.copy_from(src_blob):
+                        pass
                     self.assertEqual(src_blob.get(), dst_blob.get())
             with self.subTest("blob not found", blobstore=bs):
                 with self.assertRaises(BlobNotFoundError):
-                    bs.blob(_fake_key(bs)).copy_from(bs.blob(_fake_key(bs)))
+                    for part_size in bs.blob(_fake_key(bs)).copy_from(bs.blob(_fake_key(bs))):
+                        pass
 
     def test_download(self):
         dst_path = local_blobstore.blob(f"{uuid4()}").url
@@ -141,17 +143,20 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             for expected_data, src_blob in [(test_data.oneshot_data, test_data.oneshot_blob(bs)),
                                             (test_data.multipart_data, test_data.multipart_blob(bs))]:
                 with self.subTest(key=src_blob.key, blobstore=bs):
-                    src_blob.download(dst_path)
+                    for part_size in src_blob.download(dst_path):
+                        pass
                     with open(dst_path, "rb") as fh:
                         data = fh.read()
                     self.assertEqual(expected_data, data)
                 with self.subTest("blob not found", blobstore=bs):
                     with self.assertRaises(BlobNotFoundError):
-                        bs.blob(_fake_key(bs)).download(dst_path)
+                        for part_size in bs.blob(_fake_key(bs)).download(dst_path):
+                            pass
                 dst_subdir_path = local_blobstore.blob(os.path.join(f"{uuid4()}", "nope")).url
                 with self.subTest("Subdirectories don't exist", blobstore=bs):
                     with self.assertRaises(FileNotFoundError):
-                        bs.blob(src_blob.key).download(dst_subdir_path)
+                        for part_size in bs.blob(src_blob.key).download(dst_subdir_path):
+                            pass
 
     def test_size(self):
         expected_size = randint(1, 509)

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -129,13 +129,11 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             for src_blob in (test_data.oneshot_blob(bs), test_data.multipart_blob(bs)):
                 with self.subTest(src_key=src_blob.key, dst_key=dst_key, blobstore=bs):
                     dst_blob = bs.blob(dst_key)
-                    for part_size in dst_blob.copy_from(src_blob):
-                        pass
+                    dst_blob.copy_from(src_blob)
                     self.assertEqual(src_blob.get(), dst_blob.get())
             with self.subTest("blob not found", blobstore=bs):
                 with self.assertRaises(BlobNotFoundError):
-                    for part_size in bs.blob(_fake_key(bs)).copy_from(bs.blob(_fake_key(bs))):
-                        pass
+                    bs.blob(_fake_key(bs)).copy_from(bs.blob(_fake_key(bs)))
 
     def test_download(self):
         dst_path = local_blobstore.blob(f"{uuid4()}").url
@@ -143,20 +141,17 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             for expected_data, src_blob in [(test_data.oneshot_data, test_data.oneshot_blob(bs)),
                                             (test_data.multipart_data, test_data.multipart_blob(bs))]:
                 with self.subTest(key=src_blob.key, blobstore=bs):
-                    for part_size in src_blob.download(dst_path):
-                        pass
+                    src_blob.download(dst_path)
                     with open(dst_path, "rb") as fh:
                         data = fh.read()
                     self.assertEqual(expected_data, data)
                 with self.subTest("blob not found", blobstore=bs):
                     with self.assertRaises(BlobNotFoundError):
-                        for part_size in bs.blob(_fake_key(bs)).download(dst_path):
-                            pass
+                        bs.blob(_fake_key(bs)).download(dst_path)
                 dst_subdir_path = local_blobstore.blob(os.path.join(f"{uuid4()}", "nope")).url
                 with self.subTest("Subdirectories don't exist", blobstore=bs):
                     with self.assertRaises(FileNotFoundError):
-                        for part_size in bs.blob(src_blob.key).download(dst_subdir_path):
-                            pass
+                        bs.blob(src_blob.key).download(dst_subdir_path)
 
     def test_size(self):
         expected_size = randint(1, 509)


### PR DESCRIPTION
This makes the blob interface a little more challenging to use.
There is a trade-off:
- If 'download' and 'copy_from' do not report the size of parts copied, progress reporting must be embedded into blobstore.blob code, increasing complexity and scattering progress logic across several modules.
-  On the other hand, if 'download' and 'copy_from' DO report part sizes, progress reporting logic can be consolidated into the 'copy_client' module.

On the whole, the second option seems most attractive.