### PR TITLE
Reintroduce progress indicators for copy operations

### DIFF
--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -1,10 +1,13 @@
 import os
 import logging
 import multiprocessing
+from enum import Enum
+from math import ceil
 from concurrent.futures import ProcessPoolExecutor
-from typing import Union
+from typing import Optional, Union
 
 from getm import default_chunk_size
+from getm.progress import ProgressBar, ProgressLogger
 from getm.concurrent.collections import ConcurrentHeap
 
 from terra_notebook_utils.blobstore.gs import GSBlobStore, GSBlob
@@ -19,14 +22,34 @@ AnyBlobStore = Union[GSBlobStore, URLBlobStore, LocalBlobStore]
 AnyBlob = Union[GSBlob, URLBlob, LocalBlob]
 CloudBlob = GSBlob
 
+class ProgressIndicatorType(Enum):
+    log = ProgressLogger
+    bar = ProgressBar
+
+class Progress:
+    """This class provides a globally configured progress indicator type (Mixing types would produce terrible output),
+    as well as a factory method for instantiating new indicators. Typically only a single 'bar' indicator should be
+    active at any time. Multiple 'log' indicators may be active simultaneously.
+    """
+    indicator_type: ProgressIndicatorType = ProgressIndicatorType.log
+
+    @classmethod
+    def indicator(cls, name: str, size: int):
+        if cls.indicator_type == ProgressIndicatorType.bar:
+            incriments = 40
+        elif cls.indicator_type == ProgressIndicatorType.log:
+            incriments = ceil(size / default_chunk_size / 2)
+        return cls.indicator_type.value(name, size, incriments)
+
 def _download(src_blob: AnyBlob, dst_blob: LocalBlob):
     logger.debug(f"Starting download {src_blob.url} to {dst_blob.url}")
     dirname = os.path.dirname(dst_blob.url)
     if dirname:
         os.makedirs(dirname, exist_ok=True)
     # The download methods for each Blob is expected to compute checksums
-    for part_size in src_blob.download_iter(dst_blob.url):
-        pass
+    with Progress.indicator(dst_blob.url, src_blob.size()) as progress:
+        for part_size in src_blob.download_iter(dst_blob.url):
+            progress.add(part_size)
 
 def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
     # In general it is not necesary to compute checksums for intra cloud copies. The Storage services will do that for
@@ -35,16 +58,19 @@ def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
     # compute the destination S3Etag on the fly.
     logger.debug(f"Starting intra-cloud {src_blob.url} to {dst_blob.url}")
     assert isinstance(src_blob, type(dst_blob))
-    for part_size in dst_blob.copy_from_iter(src_blob):  # type: ignore
-        pass
+    with Progress.indicator(dst_blob.url, src_blob.size()) as progress:
+        for part_size in dst_blob.copy_from_iter(src_blob):  # type: ignore
+            progress.add(part_size)
     if src_blob.cloud_native_checksum() != dst_blob.cloud_native_checksum():
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")
         raise BlobstoreChecksumError()
 
 def _copy_oneshot_passthrough(src_blob: AnyBlob, dst_blob: CloudBlob):
     logger.debug(f"Starting oneshot passthrough {src_blob.url} to {dst_blob.url}")
-    data = src_blob.get()
-    dst_blob.put(data)
+    with Progress.indicator(dst_blob.url, src_blob.size()) as progress:
+        data = src_blob.get()
+        dst_blob.put(data)
+        progress.add(len(data))
     if not dst_blob.Hasher(data).matches(dst_blob.cloud_native_checksum()):
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")
         raise BlobstoreChecksumError()
@@ -52,10 +78,12 @@ def _copy_oneshot_passthrough(src_blob: AnyBlob, dst_blob: CloudBlob):
 def _copy_multipart_passthrough(src_blob: AnyBlob, dst_blob: CloudBlob):
     logger.debug(f"Starting multipart passthrough {src_blob.url} to {dst_blob.url}")
     cs = dst_blob.Hasher()
-    with dst_blob.multipart_writer() as writer:
-        for part in src_blob.iter_content():
-            writer.put_part(part)
-            cs.update(part.data)
+    with Progress.indicator(dst_blob.url, src_blob.size()) as progress:
+        with dst_blob.multipart_writer() as writer:
+            for part in src_blob.iter_content():
+                writer.put_part(part)
+                cs.update(part.data)
+                progress.add(len(part.data))
     if not cs.matches(dst_blob.cloud_native_checksum()):
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")
         raise BlobstoreChecksumError()
@@ -73,7 +101,7 @@ def _do_copy(src_blob: AnyBlob, dst_blob: AnyBlob, multipart_threshold: int):
                 _copy_multipart_passthrough(src_blob, dst_blob)
         else:
             raise TypeError(f"Cannot handle copy operation for blob types '{type(src_blob)}' and '{type(dst_blob)}'")
-        logger.info(f"Copied {src_blob.url} to {dst_blob.url}")
+        logger.debug(f"Copied {src_blob.url} to {dst_blob.url}")
     except Exception:
         logger.exception(f"copy failed: '{src_blob.url}' to '{dst_blob.url}'")
         try:
@@ -97,7 +125,10 @@ def blob_for_url(url: str) -> AnyBlob:
 class CopyClient:
     multipart_threshold = default_chunk_size
 
-    def __init__(self, concurrency: int=multiprocessing.cpu_count(), raise_on_error: bool=False):
+    def __init__(self,
+                 concurrency: int=multiprocessing.cpu_count(),
+                 raise_on_error: bool=False,
+                 progress_indicator: Optional[str]=None):
         """If 'raise_on_error' is False, all copy operations will be attempted even if one or more operations error. If
         'raise_on_error' is True, the first error encountered will be raise and all scheduled operations will be
         canceled.
@@ -105,6 +136,9 @@ class CopyClient:
         self._executor = ProcessPoolExecutor(max_workers=concurrency)
         self._queue = ConcurrentHeap(self._executor, concurrency)
         self.raise_on_error = raise_on_error
+        self._old_indicator_type = Progress.indicator_type
+        if progress_indicator:
+            Progress.indicator_type = ProgressIndicatorType[progress_indicator]
 
     def copy(self, src: Union[str, AnyBlob], dst: Union[str, AnyBlob]):
         if isinstance(src, str):
@@ -127,8 +161,9 @@ class CopyClient:
                         self._queue.abort()
                         raise
         finally:
+            Progress.indicator_type = self._old_indicator_type
             self._executor.shutdown()
 
 def copy(src: Union[str, AnyBlob], dst: Union[str, AnyBlob]):
-    with CopyClient() as client:
+    with CopyClient(progress_indicator="bar") as client:
         client.copy(src, dst)

--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -36,10 +36,10 @@ class Progress:
     @classmethod
     def indicator(cls, name: str, size: int):
         if cls.indicator_type == ProgressIndicatorType.bar:
-            incriments = 40
+            increments = 40
         elif cls.indicator_type == ProgressIndicatorType.log:
-            incriments = ceil(size / default_chunk_size / 2)
-        return cls.indicator_type.value(name, size, incriments)
+            increments = ceil(size / default_chunk_size / 2)
+        return cls.indicator_type.value(name, size, increments)
 
 def _download(src_blob: AnyBlob, dst_blob: LocalBlob):
     logger.debug(f"Starting download {src_blob.url} to {dst_blob.url}")
@@ -52,7 +52,7 @@ def _download(src_blob: AnyBlob, dst_blob: LocalBlob):
             progress.add(part_size)
 
 def _copy_intra_cloud(src_blob: AnyBlob, dst_blob: AnyBlob):
-    # In general it is not necesary to compute checksums for intra cloud copies. The Storage services will do that for
+    # In general it is not necessary to compute checksums for intra cloud copies. The Storage services will do that for
     # us.
     # However, S3Etags depend on the part layout. Either ensure source and destination part layouts are the same, or
     # compute the destination S3Etag on the fly.

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -64,7 +64,7 @@ def get_drs(drs_url: str) -> Response:
         'content-type': "application/json"
     }
 
-    logger.info(f"Resolving DRS uri '{drs_url}' through '{MARTHA_URL}'.")
+    logger.debug(f"Resolving DRS uri '{drs_url}' through '{MARTHA_URL}'.")
 
     json_body = dict(url=drs_url)
     resp = http.post(MARTHA_URL, headers=headers, json=json_body)
@@ -185,7 +185,6 @@ def copy_to_local(drs_url: str,
                   workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     """Copy a DRS object to the local filesystem."""
     enable_requester_pays(workspace_name, workspace_namespace)
-    logger.info(f"Downloading {drs_url} to {filepath}")
     info = get_drs_info(drs_url)
     copy_client.copy(get_drs_blob(info, workspace_namespace), _resolve_target(filepath, info))
 
@@ -224,7 +223,6 @@ def copy_to_bucket(drs_url: str,
         dst_key = src_info.name or src_info.key.rsplit("/", 1)[-1]
     src_blob = get_drs_blob(src_info, workspace_namespace)
     dst_blob = GSBlob(dst_bucket_name, dst_key)
-    logger.info(f"Beginning to copy from {src_blob.url} to {dst_blob.url}. This can take a while for large files...")
     copy_client.copy(src_blob, dst_blob)
 
 def copy(drs_url: str,
@@ -249,7 +247,7 @@ def copy_batch(drs_urls: Iterable[str],
                workspace_name: Optional[str]=WORKSPACE_NAME,
                workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     enable_requester_pays(workspace_name, workspace_namespace)
-    with copy_client.CopyClient() as cc:
+    with copy_client.CopyClient(progress_indicator="log") as cc:
         for drs_url in drs_urls:
             src_info = get_drs_info(drs_url)
             src_blob = get_drs_blob(src_info, workspace_namespace)


### PR DESCRIPTION
This uses progress indicators from [getm](https://github.com/xbrianh/getm). Some logging has been reduced to 'debug' or removed completely in favor of the progress indicators.

depends on #315 