### PR TITLE
Use ordered part iterators and writers

### DIFF
--- a/terra_notebook_utils/blobstore/__init__.py
+++ b/terra_notebook_utils/blobstore/__init__.py
@@ -63,21 +63,18 @@ class Blob:
     def iter_content(self) -> "PartIterator":
         raise NotImplementedError()
 
-    def multipart_writer(self) -> "MultipartWriter":
+    def part_writer(self) -> "PartWriter":
         raise NotImplementedError()
-
-Part = namedtuple("Part", "number data")
 
 class PartIterator:
     def __len__(self):
         raise NotImplementedError()
 
-    def __iter__(self) -> Generator[Part, None, None]:
+    def __iter__(self) -> Generator[bytes, None, None]:
         raise NotImplementedError()
 
-
-class MultipartWriter:
-    def put_part(self, part: Part):
+class PartWriter:
+    def put_part(self, part: bytes):
         raise NotImplementedError()
 
     def close(self):

--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -79,11 +79,11 @@ def _copy_multipart_passthrough(src_blob: AnyBlob, dst_blob: CloudBlob):
     logger.debug(f"Starting multipart passthrough {src_blob.url} to {dst_blob.url}")
     cs = dst_blob.Hasher()
     with Progress.indicator(dst_blob.url, src_blob.size()) as progress:
-        with dst_blob.multipart_writer() as writer:
+        with dst_blob.part_writer() as writer:
             for part in src_blob.iter_content():
                 writer.put_part(part)
-                cs.update(part.data)
-                progress.add(len(part.data))
+                cs.update(part)
+                progress.add(len(part))
     if not cs.matches(dst_blob.cloud_native_checksum()):
         logger.error(f"Checksum failed for {src_blob.url} to {dst_blob.url}")
         raise BlobstoreChecksumError()

--- a/terra_notebook_utils/blobstore/url.py
+++ b/terra_notebook_utils/blobstore/url.py
@@ -106,7 +106,7 @@ class URLPartIterator(blobstore.PartIterator):
 
     def __iter__(self):
         if 0 == http.size(self.url):
-            yield blobstore.Part(0, b"")
+            yield b""
         else:
             for data in URLReaderKeepAlive.iter_content(self.url, self.chunk_size):
                 yield data

--- a/terra_notebook_utils/blobstore/url.py
+++ b/terra_notebook_utils/blobstore/url.py
@@ -82,9 +82,9 @@ class URLBlob(blobstore.Blob):
                 yield self.size()
             else:
                 for part in self.iter_content():
-                    cs.update(part.data)
-                    fh.write(part.data)
-                    yield len(part.data)
+                    cs.update(part)
+                    fh.write(part)
+                    yield len(part)
             assert cs.matches(), "Checksum failed!"
 
     def download(self, path: str):
@@ -108,5 +108,5 @@ class URLPartIterator(blobstore.PartIterator):
         if 0 == http.size(self.url):
             yield blobstore.Part(0, b"")
         else:
-            for i, data in enumerate(URLReaderKeepAlive.iter_content(self.url, self.chunk_size)):
-                yield blobstore.Part(i, data)
+            for data in URLReaderKeepAlive.iter_content(self.url, self.chunk_size):
+                yield data

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -181,17 +181,15 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
             expected_parts = [test_data.multipart_data[i * bs.chunk_size:(i + 1) * bs.chunk_size]
                               for i in range(number_of_parts)]
             with self.subTest(test_name):
-                count = 0
-                for part_number, data in blob.iter_content():
+                for part_number, data in enumerate(blob.iter_content()):
                     self.assertEqual(expected_parts[part_number], data)
-                    count += 1
-                self.assertEqual(number_of_parts, count)
+                self.assertEqual(number_of_parts, part_number + 1)
 
                 zero_blob = bs.blob(_put_blob(bs, b""))
-                for part_number, data in zero_blob.iter_content():
-                    pass
+                for part_number, part in enumerate(zero_blob.iter_content()):
+                    data = bytes(part)
                 self.assertEqual(0, part_number)
-                self.assertEqual(b"", data)
+                self.assertEqual(b"", bytes(data))
 
         with self.subTest("shuold raise 'BlobNotFoundError'"):
             with self.assertRaises(BlobNotFoundError):


### PR DESCRIPTION
The unordered logic is more complex and doesn't provide compelling performance. Dump it.
    
Introduce local part writer.