### PR TITLE
Output json-like data from table list-rows cli

### DIFF
--- a/terra_notebook_utils/cli/commands/table.py
+++ b/terra_notebook_utils/cli/commands/table.py
@@ -38,7 +38,7 @@ def list_rows(args: argparse.Namespace):
     """
     args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
     for row in tnu_table.list_rows(args.table, args.workspace, args.workspace_namespace):
-        print(row.name, row.attributes)
+        print(json.dumps({f"{args.table}_id": row.name, **row.attributes}))
 
 @table_cli.command("get-row", arguments={
     "--table": dict(type=str, required=True, help="table name"),
@@ -51,7 +51,7 @@ def get_row(args: argparse.Namespace):
     args.workspace, args.workspace_namespace = Config.resolve(args.workspace, args.workspace_namespace)
     row = tnu_table.get_row(args.table, args.row, args.workspace, args.workspace_namespace)
     if row is not None:
-        print(row.name, json.dumps(row.attributes))
+        print(json.dumps({f"{args.table}_id": row.name, **row.attributes}))
 
 @table_cli.command("delete-table", arguments={
     "--table": dict(type=str, required=True, help="table name"),
@@ -108,3 +108,4 @@ def put_row(args: argparse.Namespace):
         attributes[key] = val
     row = tnu_table.Row(name=args.row or f"{uuid4()}", attributes=attributes)
     tnu_table.put_row(args.table, row, args.workspace, args.workspace_namespace)
+    print(json.dumps({f"{args.table}_id": row.name, **row.attributes}))

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -170,10 +170,10 @@ class TestTerraNotebookUtilsCLI_Table(CLITestMixin, unittest.TestCase):
         out = self._test_cmd(terra_notebook_utils.cli.commands.table.get_row,
                              table=self.table,
                              row=self.entity_id)
-        row_name, data = out.split(maxsplit=1)
-        attributes = json.loads(data)
-        attributes['entity_id'] = row_name  # TODO: refactor `entity_id` out of test data
-        self.assertEqual(attributes, self.table_data[self.row_index])
+        data = json.loads(out)
+        data['entity_id'] = data[f'{self.table}_id']
+        del data[f'{self.table}_id']
+        self.assertEqual(data, self.table_data[self.row_index])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This makes it easier to work with row IO on the CLI, and produces output more similar to the Terra UI.

For instance this now works:
```
tnu table list-rows | jq
```