### PR TITLE
Move drs resolution during copy into background

### DIFF
--- a/terra_notebook_utils/cli/commands/drs.py
+++ b/terra_notebook_utils/cli/commands/drs.py
@@ -58,7 +58,7 @@ def drs_copy_batch(args: argparse.Namespace):
     """
     Copy several drs:// objects to local directory or Google Storage bucket
     examples:
-        tnu drs copy-batch drs://my-drs-1 drs://my-drs-2 drs://my-drs-3 --dst /tmp/doom
+        tnu drs copy-batch drs://my-drs-1 drs://my-drs-2 drs://my-drs-3 --dst /tmp/doom/
         tnu drs copy-batch drs://my-drs-1 drs://my-drs-2 drs://my-drs-3 --dst gs://my-cool-bucket/my-cool-folder
         tnu drs copy-batch --manifest manifest.json
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -207,17 +207,15 @@ def _do_copy_drs(drs_uri: str,
                  workspace_name: Optional[str]=WORKSPACE_NAME,
                  workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     dst_blob: Union[GSBlob, URLBlob, LocalBlob]
+    src_info = get_drs_info(drs_uri)
+    src_blob = get_drs_blob(src_info, workspace_namespace)
     if dst.startswith("gs://"):
-        src_info = get_drs_info(drs_uri)
-        src_blob = get_drs_blob(src_info, workspace_namespace)
         bucket_name, key = _resolve_bucket_target(dst, src_info)
         dst_blob = GSBlob(bucket_name, key)
-        copy_client._do_copy(src_blob, dst_blob, multipart_threshold)
     else:
         info = get_drs_info(drs_uri)
-        src_blob = get_drs_blob(info, workspace_namespace)
         dst_blob = copy_client.blob_for_url(_resolve_local_target(dst, info))
-        copy_client._do_copy(src_blob, dst_blob, multipart_threshold)
+    copy_client._do_copy(src_blob, dst_blob, multipart_threshold)
 
 class DRSCopyClient(copy_client.CopyClient):
     workspace: Optional[str] = None


### PR DESCRIPTION
Previously DRS resolution was performed serially in the main
thread/process. This moves DRS resolution into the background,
improving batch copy performance.