### PR TITLE
Avoid writing empty CLI config file

### DIFF
--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -22,10 +22,9 @@ class Config:
 
     @classmethod
     def load(cls):
-        if not os.path.isfile(cls.path):
-            cls.write()
-        with open(cls.path) as fh:
-            cls.info = json.loads(fh.read())
+        if os.path.isfile(cls.path):
+            with open(cls.path) as fh:
+                cls.info = json.loads(fh.read())
 
     @classmethod
     def write(cls):


### PR DESCRIPTION
Other than the pointlessness of writing an empty config file, this prevents intermittent CI/CD false negatives.