### PR TITLE
Consolidate loggers

### DIFF
--- a/terra_notebook_utils/blobstore/copy_client.py
+++ b/terra_notebook_utils/blobstore/copy_client.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import multiprocessing
 from enum import Enum
 from math import ceil
@@ -14,9 +13,8 @@ from terra_notebook_utils.blobstore.gs import GSBlobStore, GSBlob
 from terra_notebook_utils.blobstore.url import URLBlobStore, URLBlob
 from terra_notebook_utils.blobstore.local import LocalBlobStore, LocalBlob
 from terra_notebook_utils.blobstore import BlobstoreChecksumError
+from terra_notebook_utils.logger import logger
 
-
-logger = logging.getLogger(__name__)
 
 AnyBlobStore = Union[GSBlobStore, URLBlobStore, LocalBlobStore]
 AnyBlob = Union[GSBlob, URLBlob, LocalBlob]

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -1,6 +1,5 @@
 """Utilities for working with DRS objects."""
 import os
-import logging
 import traceback
 from functools import lru_cache
 from collections import namedtuple
@@ -15,9 +14,8 @@ from terra_notebook_utils.blobstore.gs import GSBlob
 from terra_notebook_utils.blobstore.local import LocalBlob
 from terra_notebook_utils.blobstore.url import URLBlob
 from terra_notebook_utils.blobstore import Blob, copy_client, BlobNotFoundError
+from terra_notebook_utils.logger import logger
 
-
-logger = logging.getLogger(__name__)
 
 DRSInfo = namedtuple("DRSInfo", "credentials access_url bucket_name key name size updated")
 

--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -7,10 +7,11 @@ from google.oauth2 import service_account
 import google.auth
 
 from terra_notebook_utils import TERRA_DEPLOYMENT_ENV
+from terra_notebook_utils.logger import logger
 
 
-logging.getLogger("google.resumable_media.requests.download").setLevel(logging.WARNING)
-logging.getLogger("gs_chunked_io.writer").setLevel(logging.WARNING)
+logging.getLogger("google.resumable_media.requests.download").setLevel(logger.getEffectiveLevel())
+logging.getLogger("gs_chunked_io.writer").setLevel(logger.getEffectiveLevel())
 
 # Suppress the annoying google gcloud _CLOUD_SDK_CREDENTIALS_WARNING warnings
 warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")

--- a/terra_notebook_utils/logger.py
+++ b/terra_notebook_utils/logger.py
@@ -1,0 +1,4 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)

--- a/terra_notebook_utils/workflows.py
+++ b/terra_notebook_utils/workflows.py
@@ -1,6 +1,5 @@
 """Workflow information."""
 import json
-import logging
 from datetime import datetime
 from functools import lru_cache
 from typing import Dict, Generator, Optional, Tuple
@@ -9,9 +8,8 @@ from firecloud import fiss
 
 from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT, costs
 from terra_notebook_utils.utils import concurrent_recursion, js_get
+from terra_notebook_utils.logger import logger
 
-
-logger = logging.getLogger(__name__)
 
 date_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 


### PR DESCRIPTION
It makes sense for tnu to use a single logger (since it is an
interdependent set of modules)
 - easier to set the log level for the library as a whole
 - easier to reformat log messaging in the future