### PR TITLE
Update CLI config file data into defaults

### DIFF
--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -24,7 +24,7 @@ class Config:
     def load(cls):
         if os.path.isfile(cls.path):
             with open(cls.path) as fh:
-                cls.info = json.loads(fh.read())
+                cls.info.update(json.loads(fh.read()))
 
     @classmethod
     def write(cls):


### PR DESCRIPTION
This prevents loss of default configurations that aren't present
in the config file. For instance, when updating TNU with new
CLI configuration values.