### PR TITLE
Add CLI configuration for copy progress indicators

### DIFF
--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -14,11 +14,22 @@ from typing import Optional, Tuple
 import cli_builder
 
 from terra_notebook_utils import version, WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils.blobstore.progress import Indicator
 
 
 class CLIConfig:
-    info = dict(workspace=None, workspace_namespace=None)
+    info = dict(workspace=None, workspace_namespace=None, copy_progress_indicator_type="auto")
     path = os.path.join(os.path.expanduser("~"), ".tnu_config")
+
+    @classmethod
+    def progress_indicator_type(cls) -> Optional[Indicator]:
+        val = CLIConfig.info['copy_progress_indicator_type']
+        if "log" == val:
+            return Indicator.log
+        elif "auto" == val:
+            return None
+        else:
+            raise ValueError(f"Unsupported copy progress indicator type '{val}'")
 
     @classmethod
     def load(cls):

--- a/terra_notebook_utils/cli/commands/config.py
+++ b/terra_notebook_utils/cli/commands/config.py
@@ -30,6 +30,19 @@ def set_config_workspace_namespace(args: argparse.Namespace):
     CLIConfig.info["workspace_namespace"] = args.workspace_namespace
     CLIConfig.write()
 
+@config_cli.command("set-copy-progress-indicator-type", arguments={
+    "copy_progress_indicator_type": dict(type=str, choices=["auto", "log"])
+})
+def set_indicator_type(args: argparse.Namespace):
+    """
+    Set the indicator type for DRS copy operations.
+
+    When 'copy-progress-indicator-type' is set to 'auto', terra-notebook-utils chooses the most appropriate
+    indicator type for copy operations.
+    """
+    CLIConfig.info["copy_progress_indicator_type"] = args.copy_progress_indicator_type
+    CLIConfig.write()
+
 @config_cli.command("print")
 def config_print(args: argparse.Namespace):
     """

--- a/terra_notebook_utils/cli/commands/drs.py
+++ b/terra_notebook_utils/cli/commands/drs.py
@@ -46,7 +46,10 @@ def drs_copy(args: argparse.Namespace):
         tnu drs copy drs://my-drs-id gs://my-cool-bucket/my-cool-bucket-key/
     """
     args.workspace, args.workspace_namespace = CLIConfig.resolve(args.workspace, args.workspace_namespace)
-    drs.copy(args.drs_url, args.dst, args.workspace, args.workspace_namespace)
+    kwargs: Dict[str, Any] = dict(workspace_name=args.workspace, workspace_namespace=args.workspace_namespace)
+    if CLIConfig.progress_indicator_type() is not None:
+        kwargs['indicator_type'] = CLIConfig.progress_indicator_type()
+    drs.copy(args.drs_url, args.dst, **kwargs)
 
 @drs_cli.command("copy-batch", arguments={
     "drs_uris": dict(type=str, nargs="*", help="space separated list of drs:// URIs"),
@@ -87,7 +90,10 @@ def drs_copy_batch(args: argparse.Namespace):
     else:
         raise RuntimeError("Must supply either 'drs_uris' or '--manifest'")
     args.workspace, args.workspace_namespace = CLIConfig.resolve(args.workspace, args.workspace_namespace)
-    drs.copy_batch(manifest, args.workspace, args.workspace_namespace)
+    kwargs: Dict[str, Any] = dict(workspace_name=args.workspace, workspace_namespace=args.workspace_namespace)
+    if CLIConfig.progress_indicator_type() is not None:
+        kwargs['indicator_type'] = CLIConfig.progress_indicator_type()
+    drs.copy_batch(manifest, **kwargs)
 
 @drs_cli.command("head", arguments={
     "drs_url": dict(type=str),

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -27,6 +27,7 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
     def test_config_print(self):
         workspace = f"{uuid4()}"
         workspace_namespace = f"{uuid4()}"
+        copy_progress_indicator_type = "auto"
         with NamedTemporaryFile() as tf:
             with CLIConfigOverride(workspace, workspace_namespace, tf.name):
                 CLIConfig.write()
@@ -35,7 +36,9 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
                 with redirect_stdout(out):
                     terra_notebook_utils.cli.commands.config.config_print(args)
                 data = json.loads(out.getvalue())
-                self.assertEqual(data, dict(workspace=workspace, workspace_namespace=workspace_namespace))
+                self.assertEqual(data, dict(workspace=workspace,
+                                            workspace_namespace=workspace_namespace,
+                                            copy_progress_indicator_type=copy_progress_indicator_type))
 
     def test_resolve(self):
         with self.subTest("Should fall back to env vars if arguments are None and config file missing"):
@@ -69,6 +72,7 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
     def test_config_set(self):
         new_workspace = f"{uuid4()}"
         new_workspace_namespace = f"{uuid4()}"
+        new_copy_progress_indicator_type = "log"
         with NamedTemporaryFile() as tf:
             with CLIConfigOverride(None, None, tf.name):
                 CLIConfig.write()
@@ -76,10 +80,13 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
                 terra_notebook_utils.cli.commands.config.set_config_workspace(args)
                 args = argparse.Namespace(workspace_namespace=new_workspace_namespace)
                 terra_notebook_utils.cli.commands.config.set_config_workspace_namespace(args)
+                args = argparse.Namespace(copy_progress_indicator_type=new_copy_progress_indicator_type)
+                terra_notebook_utils.cli.commands.config.set_indicator_type(args)
                 with open(tf.name) as fh:
                     data = json.loads(fh.read())
                 self.assertEqual(data, dict(workspace=new_workspace,
-                                            workspace_namespace=new_workspace_namespace))
+                                            workspace_namespace=new_workspace_namespace,
+                                            copy_progress_indicator_type="log"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The possible configurations are 'log' or 'auto'.

- 'log': Progress is indicated with log messages
- 'auto': Depending on the copy operation, progress is
  indicated with either log messages or progress bars.

depends on #348 