### PR TITLE
md5 property for GSBlob

### DIFF
--- a/terra_notebook_utils/blobstore/gs.py
+++ b/terra_notebook_utils/blobstore/gs.py
@@ -1,4 +1,5 @@
 import io
+import base64
 import multiprocessing
 from math import ceil
 from concurrent.futures import ThreadPoolExecutor
@@ -156,6 +157,11 @@ class GSBlob(blobstore.Blob):
 
     def cloud_native_checksum(self) -> str:
         return self._get_native_blob().crc32c
+
+    @property
+    def md5(self) -> str:
+        gs_md5 = self._get_native_blob().md5_hash
+        return base64.b64decode(gs_md5).hex()
 
     @property
     def Hasher(self) -> checksum._Hasher:

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -97,6 +97,13 @@ class TestBlobStore(infra.SuppressWarningsMixin, unittest.TestCase):
     def test_schema(self):
         self.assertEqual("gs://", GSBlobStore.schema)
 
+    def test_gs_md5(self):
+        data = os.urandom(32)
+        blob = gs_blobstore.blob(f"{uuid4()}")
+        blob.put(data)
+        self.assertEqual(blob.md5,
+                         checksum.MD5(data)._checksum.hexdigest())
+
     def test_put_get_delete(self):
         key = f"{uuid4()}"
         expected_data = os.urandom(1021)


### PR DESCRIPTION
This is useful for checksum verification for DRS responses containing a signed URL and a known hash.