### PR TITLE
Use new image for CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,13 @@
 image: ubuntu:latest
 
+variables:
+  PYTHONIOENCODING: "utf-8"
+  DEBIAN_FRONTEND: "noninteractive"
+
 before_script:
   - date && date -u
-  - apt-get install -y virtualenv
+  - apt-get update
+  - apt-get install -y software-properties-common build-essential virtualenv
   - virtualenv ~/venv
   - source ~/venv/bin/activate
   - pip install -r requirements-dev.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
 before_script:
   - date && date -u
   - apt-get update
-  - apt-get install -y software-properties-common build-essential virtualenv
+  - apt-get install -y software-properties-common build-essential virtualenv python3 python3-dev
   - virtualenv ~/venv
   - source ~/venv/bin/activate
   - pip install -r requirements-dev.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: ubuntu:latest
 
 before_script:
   - date && date -u
+  - apt-get install -y virtualenv
   - virtualenv ~/venv
   - source ~/venv/bin/activate
   - pip install -r requirements-dev.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: quay.io/python-devs/ci-image
+image: ubuntu:latest
 
 before_script:
   - date && date -u


### PR DESCRIPTION
The old image `quay.io/python-devs/ci-image` appears to no longer be publicly available.

I may change this to a slim version and some kind of self-maintained, self-updating quay.io image at some point, but this should work to test things for now.