### PR TITLE
Better debug message.

### DIFF
--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -152,7 +152,7 @@ def _drs_info_from_martha_v3(drs_url: str, drs_data: dict) -> DRSInfo:
 
 def get_drs_info(drs_url: str) -> DRSInfo:
     """Attempt to resolve gs:// url and credentials for a DRS object."""
-    assert drs_url.startswith("drs://"), "Expected DRS URI of the form 'drs://...', got '{drs_url}'"
+    assert drs_url.startswith("drs://"), f"Expected DRS URI of the form 'drs://...', got '{drs_url}'"
     drs_data = get_drs(drs_url).json()
     if 'dos' in drs_data:
         return _drs_info_from_martha_v2(drs_url, drs_data)
@@ -166,14 +166,13 @@ def get_drs_blob(drs_url_or_info: Union[str, DRSInfo],
     elif isinstance(drs_url_or_info, DRSInfo):
         info = drs_url_or_info
     else:
-        raise TypeError()
+        raise TypeError(f'Unexpected DRS input type ({type(drs_url_or_info)}): {drs_url_or_info}')
     blob: Union[URLBlob, GSBlob]
     if info.access_url is not None:
         blob = URLBlob(info.access_url, info.md5)
     else:
-        assert info.credentials
-        assert info.bucket_name
-        assert info.key
+        if not (info.credentials or info.bucket_name or info.key):
+            raise ValueError(f'DRS information is missing.  Check:\n{info}')
         blob = GSBlob(info.bucket_name, info.key, info.credentials, workspace_namespace)
     return blob
 


### PR DESCRIPTION
This should provide more information than a plain assert.

```
"""
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/jupyter/terra-notebook-utils/terra_notebook_utils/drs.py", line 225, in _do_copy_drs
    src_blob = get_drs_blob(src_info, workspace_namespace)
  File "/home/jupyter/terra-notebook-utils/terra_notebook_utils/drs.py", line 174, in get_drs_blob
    assert info.credentials
AssertionError
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jupyter/terra-notebook-utils/terra_notebook_utils/drs.py", line 259, in copy
    cc.copy(drs_uri, dst or ".")
  File "/home/jupyter/terra-notebook-utils/terra_notebook_utils/blobstore/copy_client.py", line 135, in __exit__
    f.result()
  File "/opt/conda/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/opt/conda/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
AssertionError
```