### PR TITLE
Distinguish between WORKSPACE_NAMESPACE and GOOGLE_PROJECT

### DIFF
--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -1,8 +1,8 @@
 import os
 
 WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
-WORKSPACE_NAMESPACE = os.environ.get('WORKSPACE_NAMESPACE')  # This env var is set in Terra notebooks
-WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra notebooks
+WORKSPACE_NAMESPACE = os.environ.get('WORKSPACE_NAMESPACE')  # This env var is set in Terra Cloud Environments
+WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra Cloud Environments
 TERRA_DEPLOYMENT_ENV = os.environ.get('TERRA_DEPLOYMENT_ENV', 'prod')
 MARTHA_URL_VERSION = os.environ.get('MARTHA_URL_VERSION', 'martha_v3')
 

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
+WORKSPACE_NAMESPACE = os.environ.get('WORKSPACE_NAMESPACE')  # This env var is set in Terra notebooks
 WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra notebooks
 TERRA_DEPLOYMENT_ENV = os.environ.get('TERRA_DEPLOYMENT_ENV', 'prod')
 MARTHA_URL_VERSION = os.environ.get('MARTHA_URL_VERSION', 'martha_v3')

--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple
 
 import cli_builder
 
-from terra_notebook_utils import version, WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import version, WORKSPACE_NAME, WORKSPACE_NAMESPACE
 from terra_notebook_utils.blobstore.progress import Indicator
 
 
@@ -45,9 +45,9 @@ class CLIConfig:
     @classmethod
     def resolve(cls, override_workspace: Optional[str], override_namespace: Optional[str]) -> Tuple[str, str]:
         workspace = override_workspace or (cls.info['workspace'] or WORKSPACE_NAME)
-        namespace = override_namespace or (cls.info['workspace_namespace'] or WORKSPACE_GOOGLE_PROJECT)
+        namespace = override_namespace or (cls.info['workspace_namespace'] or WORKSPACE_NAMESPACE)
         if not workspace:
-            raise RuntimeError("This command requies a workspace. Either pass in with `--workspace`,"
+            raise RuntimeError("This command requires a workspace. Either pass in with `--workspace`,"
                                " or configure the CLI (see `tnu config --help`). A default may also be configured by"
                                " setting the `WORKSPACE_NAME` env var")
         if namespace is None:
@@ -56,7 +56,7 @@ class CLIConfig:
         if not namespace:
             raise RuntimeError("This command requies a workspace namespace. Either pass in with `--workspace-namespace`"
                                ", or configure the CLI (see `tnu config --help`). A default may also be"
-                               " configued by setting the `WORKSPACE_GOOGLE_PROJECT` env var")
+                               " configued by setting the `WORKSPACE_NAMESPACE` env var")
         return workspace, namespace
 CLIConfig.load()
 

--- a/terra_notebook_utils/cli/__init__.py
+++ b/terra_notebook_utils/cli/__init__.py
@@ -54,9 +54,10 @@ class CLIConfig:
             from terra_notebook_utils.workspace import get_workspace_namespace
             namespace = get_workspace_namespace(workspace)
         if not namespace:
-            raise RuntimeError("This command requies a workspace namespace. Either pass in with `--workspace-namespace`"
-                               ", or configure the CLI (see `tnu config --help`). A default may also be"
-                               " configued by setting the `WORKSPACE_NAMESPACE` env var")
+            raise RuntimeError("This command requires a workspace namespace. "
+                               "Either pass in with `--workspace-namespace`, "
+                               "or configure the CLI (see `tnu config --help`). A default may also be"
+                               " configured by setting the `WORKSPACE_NAMESPACE` env var")
         return workspace, namespace
 CLIConfig.load()
 

--- a/terra_notebook_utils/cli/commands/drs.py
+++ b/terra_notebook_utils/cli/commands/drs.py
@@ -19,7 +19,7 @@ workspace_args: Dict[str, Dict[str, Any]] = {
     "--workspace-namespace": dict(
         type=str,
         default=CLIConfig.info['workspace_namespace'],
-        help=("The workspace namespace represents the parent folder of the workspace "
+        help=("The workspace namespace represents the parent containing the workspace "
               "(the Terra billing project) "
               "If omitted, the CLI configured `workspace_namespace` will be used. ")
     )

--- a/terra_notebook_utils/cli/commands/drs.py
+++ b/terra_notebook_utils/cli/commands/drs.py
@@ -18,11 +18,10 @@ workspace_args: Dict[str, Dict[str, Any]] = {
     ),
     "--workspace-namespace": dict(
         type=str,
-        required=False,
         default=CLIConfig.info['workspace_namespace'],
-        help=("The billing project for GS requests. "
-              "If omitted, the CLI configured `workspace_namespace` will be used. "
-              "Note that DRS URLs also involve a GS request.")
+        help=("The workspace namespace represents the parent folder of the workspace "
+              "(the Terra billing project) "
+              "If omitted, the CLI configured `workspace_namespace` will be used. ")
     )
 }
 

--- a/terra_notebook_utils/cli/commands/table.py
+++ b/terra_notebook_utils/cli/commands/table.py
@@ -15,8 +15,9 @@ table_cli = dispatch.group("table", help=tnu_table.__doc__, arguments={
     "--workspace-namespace": dict(
         type=str,
         default=None,
-        help=("workspace namespace. If not provided, the configured CLI google billing "
-              "project will be used.")
+        help=("The workspace namespace represents the parent containing the workspace "
+              "(the Terra billing project) "
+              "If omitted, the CLI configured `workspace_namespace` will be used. ")
     ),
 })
 

--- a/terra_notebook_utils/cli/commands/workflows.py
+++ b/terra_notebook_utils/cli/commands/workflows.py
@@ -22,9 +22,9 @@ workspace_args: Dict[str, Dict[str, Any]] = {
         type=str,
         required=False,
         default=CLIConfig.info['workspace_namespace'],
-        help=("The billing project for GS requests. "
-              "If omitted, the CLI configured `workspace_namespace` will be used. "
-              "Note that DRS URLs also involve a GS request.")
+        help=("The workspace namespace represents the parent containing the workspace "
+              "(the Terra billing project) "
+              "If omitted, the CLI configured `workspace_namespace` will be used. ")
     )
 }
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -94,6 +94,10 @@ def access(drs_url: str,
            workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE,
            billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> str:
     """Return a signed url for a drs:// URI, if available."""
+    # We enable requester pays by specifying the workspace/namespace combo, not
+    # with the billing project. Rawls then enables requester pays for the attached
+    # project, but this won't work if a user specifies a project unattached to
+    # the Terra workspace.
     enable_requester_pays(workspace_name, workspace_namespace)
     info = get_drs_info(drs_url)
 

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -1,15 +1,14 @@
 """Utilities for working with DRS objects."""
 import os
 import requests
-import datetime
 
 from functools import lru_cache
 from collections import namedtuple
 from typing import Dict, List, Tuple, Optional, Union
-from google.cloud import storage
 from requests import Response
 
-from terra_notebook_utils import WORKSPACE_GOOGLE_PROJECT, WORKSPACE_BUCKET, WORKSPACE_NAME, MARTHA_URL
+from terra_notebook_utils import WORKSPACE_BUCKET, WORKSPACE_NAME, MARTHA_URL, WORKSPACE_NAMESPACE, \
+    WORKSPACE_GOOGLE_PROJECT
 from terra_notebook_utils import workspace, gs, tar_gz, TERRA_DEPLOYMENT_ENV, _GS_SCHEMA
 from terra_notebook_utils.utils import is_notebook
 from terra_notebook_utils.http import http
@@ -35,7 +34,7 @@ def _parse_gs_url(gs_url: str) -> Tuple[str, str]:
 
 @lru_cache()
 def enable_requester_pays(workspace_name: Optional[str]=WORKSPACE_NAME,
-                          workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+                          workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE):
     assert workspace_name
     import urllib.parse
     encoded_workspace = urllib.parse.quote(workspace_name)
@@ -92,7 +91,8 @@ def info(drs_url: str) -> dict:
 
 def access(drs_url: str,
            workspace_name: Optional[str]=WORKSPACE_NAME,
-           workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> str:
+           workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE,
+           billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> str:
     """Return a signed url for a drs:// URI, if available."""
     enable_requester_pays(workspace_name, workspace_namespace)
     info = get_drs_info(drs_url)
@@ -111,7 +111,7 @@ def access(drs_url: str,
         return gs.get_signed_url(bucket=info.bucket_name,
                                  key=info.key,
                                  sa_credentials=info.credentials,
-                                 requester_pays_user_project=workspace_namespace)
+                                 requester_pays_user_project=billing_project)
     return url
 
 def _get_drs_gs_creds(response: dict) -> Optional[dict]:
@@ -177,7 +177,7 @@ def get_drs_info(drs_url: str) -> DRSInfo:
         return _drs_info_from_martha_v3(drs_url, drs_data)
 
 def get_drs_blob(drs_url_or_info: Union[str, DRSInfo],
-                 workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Union[GSBlob, URLBlob]:
+                 billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Union[GSBlob, URLBlob]:
     if isinstance(drs_url_or_info, str):
         info = get_drs_info(drs_url_or_info)
     elif isinstance(drs_url_or_info, DRSInfo):
@@ -190,23 +190,24 @@ def get_drs_blob(drs_url_or_info: Union[str, DRSInfo],
     else:
         if not (info.credentials or info.bucket_name or info.key):
             raise ValueError(f'DRS information is missing.  Check:\n{info}')
-        blob = GSBlob(info.bucket_name, info.key, info.credentials, workspace_namespace)
+        blob = GSBlob(info.bucket_name, info.key, info.credentials, billing_project)
     return blob
 
-def blob_for_url(url: str, workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Blob:
+def blob_for_url(url: str, billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Blob:
     if url.startswith("drs://"):
-        return get_drs_blob(url, workspace_namespace)
+        return get_drs_blob(url, billing_project)
     else:
         return copy_client.blob_for_url(url)
 
 def head(drs_url: str,
          num_bytes: int = 1,
          workspace_name: Optional[str]=WORKSPACE_NAME,
-         workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+         workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE,
+         billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     """Head a DRS object by byte."""
     enable_requester_pays(workspace_name, workspace_namespace)
     try:
-        blob = get_drs_blob(drs_url, workspace_namespace)
+        blob = get_drs_blob(drs_url, billing_project)
         with blob.open(chunk_size=num_bytes) as fh:
             the_bytes = fh.read(num_bytes)
     except (DRSResolutionError, BlobNotFoundError) as e:
@@ -233,12 +234,10 @@ def _resolve_local_target(filepath: str, info: DRSInfo) -> str:
 def _do_copy_drs(drs_uri: str,
                  dst: str,
                  multipart_threshold: int,
-                 indicator_type: Indicator,
-                 workspace_name: Optional[str]=WORKSPACE_NAME,
-                 workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+                 indicator_type: Indicator):
     dst_blob: Union[GSBlob, URLBlob, LocalBlob]
     src_info = get_drs_info(drs_uri)
-    src_blob = get_drs_blob(src_info, workspace_namespace)
+    src_blob = get_drs_blob(src_info)
     if dst.startswith("gs://"):
         bucket_name, key = _resolve_bucket_target(dst, src_info)
         dst_blob = GSBlob(bucket_name, key)
@@ -256,15 +255,13 @@ class DRSCopyClient(copy_client.CopyClient):
                         drs_uri,
                         dst,
                         self.multipart_threshold,
-                        self.indicator_type,
-                        self.workspace,
-                        self.workspace_namespace)
+                        self.indicator_type)
 
 def copy(drs_uri: str,
          dst: str,
          indicator_type: Indicator=Indicator.notebook_bar if is_notebook() else Indicator.bar,
          workspace_name: Optional[str]=WORKSPACE_NAME,
-         workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+         workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE):
     """Copy a DRS object to either the local filesystem, or to a Google Storage location if `dst` starts with
     "gs://".
     """
@@ -279,7 +276,7 @@ def copy_to_bucket(drs_uri: str,
                    dst_bucket_name: Optional[str]=None,
                    indicator_type: Indicator=Indicator.notebook_bar if is_notebook() else Indicator.bar,
                    workspace_name: Optional[str]=WORKSPACE_NAME,
-                   workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+                   workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE):
     """Resolve `drs_url` and copy into user-specified bucket `dst_bucket`.  If `dst_bucket` is None, copy into
     workspace bucket.
     """
@@ -304,7 +301,7 @@ manifest_schema = {
 def copy_batch(manifest: List[Dict[str, str]],
                indicator_type: Indicator=Indicator.notebook_bar if is_notebook() else Indicator.log,
                workspace_name: Optional[str]=WORKSPACE_NAME,
-               workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+               workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE):
     from jsonschema import validate
     validate(instance=manifest, schema=manifest_schema)
     enable_requester_pays(workspace_name, workspace_namespace)
@@ -317,13 +314,14 @@ def copy_batch(manifest: List[Dict[str, str]],
 def extract_tar_gz(drs_url: str,
                    dst: Optional[str]=None,
                    workspace_name: Optional[str]=WORKSPACE_NAME,
-                   workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
+                   workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE,
+                   billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT):
     """Extract a `.tar.gz` archive resolved by a DRS url. 'dst' may be either a local filepath or a 'gs://' url.
     Default extraction is to the bucket for 'workspace'.
     """
     dst = dst or f"gs://{workspace.get_workspace_bucket(workspace_name)}"
     enable_requester_pays(workspace_name, workspace_namespace)
-    blob = get_drs_blob(drs_url, workspace_namespace)
+    blob = get_drs_blob(drs_url, billing_project)
     with blob.open() as fh:
         tar_gz.extract(fh, dst)
 

--- a/terra_notebook_utils/workflows.py
+++ b/terra_notebook_utils/workflows.py
@@ -6,7 +6,7 @@ from typing import Dict, Generator, Optional, Tuple
 
 from firecloud import fiss
 
-from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT, costs
+from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_NAMESPACE, costs
 from terra_notebook_utils.utils import concurrent_recursion, js_get
 from terra_notebook_utils.logger import logger
 
@@ -17,7 +17,7 @@ class TNUCostException(Exception):
     pass
 
 def list_submissions(workspace_name: Optional[str]=WORKSPACE_NAME,
-                     workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Generator[dict, None, None]:
+                     workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE) -> Generator[dict, None, None]:
     resp = fiss.fapi.list_submissions(workspace_namespace, workspace_name)
     resp.raise_for_status()
     for s in resp.json():
@@ -26,7 +26,7 @@ def list_submissions(workspace_name: Optional[str]=WORKSPACE_NAME,
 @lru_cache()
 def get_submission(submission_id: str,
                    workspace_name: Optional[str]=WORKSPACE_NAME,
-                   workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
+                   workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE) -> dict:
     """Get information about a submission, including member workflows."""
     resp = fiss.fapi.get_submission(workspace_namespace, workspace_name, submission_id)
     resp.raise_for_status()
@@ -36,7 +36,7 @@ def get_submission(submission_id: str,
 def get_workflow(submission_id: str,
                  workflow_id: str,
                  workspace_name: Optional[str]=WORKSPACE_NAME,
-                 workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> dict:
+                 workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE) -> dict:
     """Get information about a workflow."""
     resp = fiss.fapi.get_workflow_metadata(workspace_namespace, workspace_name, submission_id, workflow_id)
     resp.raise_for_status()
@@ -44,7 +44,7 @@ def get_workflow(submission_id: str,
 
 def get_all_workflows(submission_id: str,
                       workspace: Optional[str]=WORKSPACE_NAME,
-                      workspace_namespace: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Dict[str, dict]:
+                      workspace_namespace: Optional[str]=WORKSPACE_NAMESPACE) -> Dict[str, dict]:
     """Retrieve all workflows, and workflow metadata, for `submission_id`, including sub-workflows."""
     workflows_metadata = dict()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,8 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests import config
 from terra_notebook_utils.cli import CLIConfig
-from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_NAMESPACE
+
 
 class CLIConfigOverride:
     def __init__(self, workspace, namespace, path=None):
@@ -38,7 +39,7 @@ class CLITestMixin:
 
     def _test_cmd(self, cmd: Callable, **kwargs):
         with NamedTemporaryFile() as tf:
-            with CLIConfigOverride(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT, tf.name):
+            with CLIConfigOverride(WORKSPACE_NAME, WORKSPACE_NAMESPACE, tf.name):
                 CLIConfig.write()
                 args = argparse.Namespace(**dict(**self.common_kwargs, **kwargs))
                 out = io.StringIO()

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,6 @@
 import os
 
 os.environ['GCLOUD_PROJECT'] = os.environ.get('GCLOUD_PROJECT', "firecloud-cgl")
+os.environ['WORKSPACE_NAMESPACE'] = os.environ.get('WORKSPACE_NAMESPACE', "firecloud-cgl")
 os.environ['WORKSPACE_NAME'] = os.environ.get('WORKSPACE_NAME', "terra-notebook-utils-tests")
 os.environ['WORKSPACE_BUCKET'] = os.environ.get('WORKSPACE_BUCKET', "gs://fc-9169fcd1-92ce-4d60-9d2d-d19fd326ff10")

--- a/tests/infra/partialize_vcf.py
+++ b/tests/infra/partialize_vcf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests import config  # initialize the test environment
 
-from terra_notebook_utils import gs, drs, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import drs
 
 
 def partialize_vcf(uri: str, number_of_lines: int, zip_format: str="bgzip") -> bytes:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -17,7 +17,7 @@ from tests import config  # initialize the test environment
 from tests import CLIConfigOverride
 from tests.infra.testmode import testmode
 from tests.infra import SuppressWarningsMixin
-from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_NAMESPACE
 from terra_notebook_utils.cli import CLIConfig
 import terra_notebook_utils.cli.commands.config
 
@@ -45,7 +45,7 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
             with CLIConfigOverride(None, None):
                 workspace, namespace = CLIConfig.resolve(None, None)
                 self.assertEqual(WORKSPACE_NAME, workspace)
-                self.assertEqual(WORKSPACE_GOOGLE_PROJECT, namespace)
+                self.assertEqual(WORKSPACE_NAMESPACE, namespace)
         with self.subTest("Should fall back to config if arguments are None/False"):
             with CLIConfigOverride(str(uuid4()), str(uuid4())):
                 workspace, namespace = CLIConfig.resolve(None, None)
@@ -55,7 +55,7 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
             expected_namespace = str(uuid4())
             with mock.patch("terra_notebook_utils.workspace.get_workspace_namespace", return_value=expected_namespace):
                 with CLIConfigOverride(WORKSPACE_NAME, None):
-                    terra_notebook_utils.cli.WORKSPACE_GOOGLE_PROJECT = None
+                    terra_notebook_utils.cli.WORKSPACE_NAMESPACE = None
                     workspace, namespace = CLIConfig.resolve(None, None)
                     self.assertEqual(CLIConfig.info['workspace'], workspace)
                     self.assertEqual(expected_namespace, namespace)
@@ -64,7 +64,7 @@ class TestTerraNotebookUtilsCLI_Config(SuppressWarningsMixin, unittest.TestCase)
             expected_namespace = str(uuid4())
             with mock.patch("terra_notebook_utils.workspace.get_workspace_namespace", return_value=expected_namespace):
                 with CLIConfigOverride(str(uuid4()), str(uuid4())):
-                    terra_notebook_utils.cli.WORKSPACE_GOOGLE_PROJECT = None
+                    terra_notebook_utils.cli.WORKSPACE_NAMESPACE = None
                     workspace, namespace = CLIConfig.resolve(expected_workspace, expected_namespace)
                     self.assertEqual(expected_workspace, workspace)
                     self.assertEqual(expected_namespace, namespace)

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -24,7 +24,7 @@ from tests import config  # initialize the test environment
 from tests import CLITestMixin
 from tests.infra import SuppressWarningsMixin, get_env
 from tests.infra.testmode import testmode
-from terra_notebook_utils import drs, gs, WORKSPACE_GOOGLE_PROJECT, WORKSPACE_BUCKET, WORKSPACE_NAME
+from terra_notebook_utils import drs, gs, WORKSPACE_BUCKET, WORKSPACE_NAME, WORKSPACE_NAMESPACE
 import terra_notebook_utils.cli.commands.drs
 
 
@@ -387,15 +387,15 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
                 with self.subTest("Copy to local"):
                     with tempfile.NamedTemporaryFile() as tf:
                         drs.copy(self.drs_url, tf.name)
-                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
+                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_NAMESPACE)
                 with self.subTest("Copy to bucket"):
                     enable_requester_pays.reset_mock()
                     drs.copy(self.drs_url, "gs://some_bucket/some_key")
-                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
+                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_NAMESPACE)
                 with self.subTest("Extract tarball"):
                     enable_requester_pays.reset_mock()
                     drs.extract_tar_gz(self.drs_url)
-                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT)
+                    enable_requester_pays.assert_called_with(WORKSPACE_NAME, WORKSPACE_NAMESPACE)
 
     # test for when we get everything what we wanted in martha_v3 response
     def test_martha_v3_response(self):
@@ -577,7 +577,7 @@ class TestTerraNotebookUtilsCLI_DRSInDev(CLITestMixin, unittest.TestCase):
                                drs_url=self.jade_dev_url,
                                dst=tf.name,
                                workspace=WORKSPACE_NAME,
-                               workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+                               workspace_namespace=WORKSPACE_NAMESPACE)
                 with open(tf.name, "rb") as fh:
                     data = fh.read()
                 self.assertEqual(_crc32c(data), self.expected_crc32c)
@@ -588,7 +588,7 @@ class TestTerraNotebookUtilsCLI_DRSInDev(CLITestMixin, unittest.TestCase):
                            drs_url=self.jade_dev_url,
                            dst=f"gs://{WORKSPACE_BUCKET}/{key}",
                            workspace=WORKSPACE_NAME,
-                           workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+                           workspace_namespace=WORKSPACE_NAMESPACE)
             blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
             out = io.BytesIO()
             blob.download_to_file(out)
@@ -609,7 +609,7 @@ class TestTerraNotebookUtilsCLI_DRS(CLITestMixin, unittest.TestCase):
                                drs_url=self.drs_url,
                                dst=tf.name,
                                workspace=WORKSPACE_NAME,
-                               workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+                               workspace_namespace=WORKSPACE_NAMESPACE)
                 with open(tf.name, "rb") as fh:
                     data = fh.read()
                 self.assertEqual(_crc32c(data), self.expected_crc32c)
@@ -620,7 +620,7 @@ class TestTerraNotebookUtilsCLI_DRS(CLITestMixin, unittest.TestCase):
                            drs_url=self.drs_url,
                            dst=f"gs://{WORKSPACE_BUCKET}/{key}",
                            workspace=WORKSPACE_NAME,
-                           workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+                           workspace_namespace=WORKSPACE_NAMESPACE)
             blob = gs.get_client().bucket(WORKSPACE_BUCKET).get_blob(key)
             out = io.BytesIO()
             blob.download_to_file(out)
@@ -632,7 +632,7 @@ class TestTerraNotebookUtilsCLI_DRS(CLITestMixin, unittest.TestCase):
         def _test_head(uri: str, num_bytes: int, expected_error: Optional[Exception]=None):
             cmd = [f'{pkg_root}/dev_scripts/tnu', 'drs', 'head', uri,
                    f'--workspace={WORKSPACE_NAME}',
-                   f'--workspace-namespace={WORKSPACE_GOOGLE_PROJECT}']
+                   f'--workspace-namespace={WORKSPACE_NAMESPACE}']
             if 1 < num_bytes:
                 cmd.append(f"--bytes={num_bytes}")
             with self.subTest(uri=uri, num_bytes=num_bytes, expected_error=expected_error):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -14,7 +14,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests import config  # initialize the test environment
 from tests import CLITestMixin
 from tests.infra.testmode import testmode
-from terra_notebook_utils import table as tnu_table, WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import table as tnu_table, WORKSPACE_NAME, WORKSPACE_NAMESPACE
 from tests.infra import SuppressWarningsMixin
 import terra_notebook_utils.cli.commands.table
 
@@ -135,7 +135,7 @@ class TestTerraNotebookUtilsTable(SuppressWarningsMixin, unittest.TestCase):
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsCLI_Table(CLITestMixin, unittest.TestCase):
-    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_NAMESPACE)
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -14,7 +14,7 @@ from tests import CLITestMixin
 from tests.infra import SuppressWarningsMixin, upload_data
 from tests.infra.partialize_vcf import partialize_vcf
 
-from terra_notebook_utils import vcf, drs, WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT, WORKSPACE_BUCKET
+from terra_notebook_utils import vcf, drs, WORKSPACE_BUCKET, WORKSPACE_GOOGLE_PROJECT
 import terra_notebook_utils.cli.commands.vcf
 
 
@@ -45,7 +45,7 @@ class TestTerraNotebookUtilsVCF(SuppressWarningsMixin, unittest.TestCase):
                     self.assertEqual("10133", info.pos)
 
 class TestTerraNotebookUtilsCLI_VCF(SuppressWarningsMixin, CLITestMixin, unittest.TestCase):
-    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+    common_kwargs = dict(billing_project=WORKSPACE_GOOGLE_PROJECT)
     vcf_drs_url = "drs://dg.4503/57f58130-2d66-4d46-9b2b-539f7e6c2080"
 
     @classmethod

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -13,7 +13,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests import config  # initialize the test environment
 from tests import CLITestMixin
 from tests.infra.testmode import testmode
-from terra_notebook_utils import workflows, WORKSPACE_NAME, WORKSPACE_GOOGLE_PROJECT
+from terra_notebook_utils import workflows, WORKSPACE_NAME, WORKSPACE_NAMESPACE
 import terra_notebook_utils.cli.commands.workflows
 
 
@@ -41,7 +41,7 @@ class TestTerraNotebookUtilsWorkflows(unittest.TestCase):
 
 @testmode("workspace_access")
 class TestTerraNotebookUtilsWorkflowsCLI(CLITestMixin, unittest.TestCase):
-    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_GOOGLE_PROJECT)
+    common_kwargs = dict(workspace=WORKSPACE_NAME, workspace_namespace=WORKSPACE_NAMESPACE)
 
     def test_list_submissions(self):
         with mock.patch("terra_notebook_utils.workflows.list_submissions"):


### PR DESCRIPTION
To accommodate Terra's Project Per Workspace (PPW) changes, we now need
to distinguish between workspace name and Google projects (they were
previously the same).

This addresses (#369)