### PR TITLE
Restore list_bucket()

### DIFF
--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -145,7 +145,7 @@ def get_signed_url(bucket: str,
 
 def list_bucket(prefix: str = '', bucket: Optional[str] = None):
     """Lists blobs in "gs://bucket/prefix/"."""
-    bucket = bucket or os.environ['WORKSPACE_BUCKET']
+    bucket = bucket or os.environ.get('WORKSPACE_BUCKET')
     if bucket.startswith('gs://'):
         bucket = bucket[len('gs://'):]
 

--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -142,3 +142,17 @@ def get_signed_url(bucket: str,
 
     signature = binascii.hexlify(creds.signer.sign(string_to_sign)).decode()
     return f'https://{host}{canonical_uri}?{canonical_query_string}&x-goog-signature={signature}'
+
+def list_bucket(prefix="", bucket=os.environ['WORKSPACE_BUCKET']):
+    """
+    Lists blobs in "gs://bucket/prefix/"; used by BYOD notebook. Note that Google's list_blobs()
+    is partially depreciated, and later we may need to call it like this instead:
+    gs.get_client().list_blobs(stripped_bucket, prefix=prefix)
+    """
+    stripped_bucket = strip_gs(bucket)
+    for blob in get_client().bucket(stripped_bucket).list_blobs(prefix=prefix):
+        yield blob.name
+
+def strip_gs(bucket_with_gs):
+    # Turns "gs://some-bucket" into "some-bucket" which is the format list_blobs() requires
+    return bucket_with_gs[5:]


### PR DESCRIPTION
Used by the BYOD notebook. This was previously in gs.py but was removed sometime in summer 2021.  I also added a function to strip the gs:// part of the bucket name. If we do not strip that part, list_blobs() will throw a 404 error. I do vaguely recall having to strip the gs:// part before... not sure why it wasn't getting removed in this notebook.

Another option would be to hardcode this into the notebook itself, and that's what I did to test this. But it probably belongs here.