### PR TITLE
Check if bucket is empty string

### DIFF
--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -146,7 +146,7 @@ def get_signed_url(bucket: str,
 def list_bucket(bucket: Optional[str] = None, prefix: str = ''):
     """Lists blobs in "gs://bucket/prefix/"."""
     bucket = bucket or os.environ.get('WORKSPACE_BUCKET')
-    if not bucket:
+    if not bucket or bucket == "":
         raise RuntimeError('list_bucket: No bucket specified!  Please provide a bucket name or set WORKSPACE_BUCKET.')
     if bucket.startswith('gs://'):
         bucket = bucket[len('gs://'):]


### PR DESCRIPTION
os.environ.get('WORKSPACE_BUCKET') in list_bucket() is resulting in a 404 if the bucket name is not specified when this function is called. Based on the output I have a hunch os.environ.get('WORKSPACE_BUCKET') is returning an empty string.

A possible alternative to this based on get_access_token(), although I'm not sure if it would make a difference:
```
if os.environ.get('WORKSPACE_BUCKET'):
        bucket = os.environ['WORKSPACE_BUCKET']
```