### PR TITLE
Update Iterable import.

### DIFF
--- a/terra_notebook_utils/compat/typing.py
+++ b/terra_notebook_utils/compat/typing.py
@@ -1,0 +1,6 @@
+try:
+    # python3.10+
+    from collections.abc import Iterable
+except ImportError:
+    # python versions < 3.10
+    from collections import Iterable

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -4,12 +4,13 @@ import requests
 
 from functools import lru_cache
 from collections import namedtuple
-from typing import Dict, List, Tuple, Optional, Union, Iterable
+from typing import Dict, List, Tuple, Optional, Union
 from requests import Response
 
 from terra_notebook_utils import WORKSPACE_BUCKET, WORKSPACE_NAME, MARTHA_URL, WORKSPACE_NAMESPACE, \
     WORKSPACE_GOOGLE_PROJECT
 from terra_notebook_utils import workspace, gs, tar_gz, TERRA_DEPLOYMENT_ENV, _GS_SCHEMA
+from terra_notebook_utils.compat.typing import Iterable
 from terra_notebook_utils.utils import is_notebook
 from terra_notebook_utils.http import http
 from terra_notebook_utils.blobstore.gs import GSBlob

--- a/terra_notebook_utils/table.py
+++ b/terra_notebook_utils/table.py
@@ -3,10 +3,11 @@ import os
 from uuid import uuid4
 from functools import lru_cache
 from collections import defaultdict, namedtuple
-from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, Generator, List, Mapping, Optional, Set, Tuple, Union
 
 import requests
 
+from terra_notebook_utils.compat.typing import Iterable
 from terra_notebook_utils.http import Retry, http_session
 from terra_notebook_utils.utils import _AsyncContextManager
 from terra_notebook_utils import WORKSPACE_NAME, WORKSPACE_NAMESPACE

--- a/terra_notebook_utils/utils.py
+++ b/terra_notebook_utils/utils.py
@@ -2,9 +2,11 @@ import json
 import threading
 from functools import lru_cache
 from concurrent.futures import ThreadPoolExecutor, Future, as_completed
-from typing import Any, Callable, Dict, Optional, Iterable, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 import jmespath
+
+from terra_notebook_utils.compat.typing import Iterable
 
 
 class _AsyncContextManager:

--- a/tests/infra/partialize_vcf.py
+++ b/tests/infra/partialize_vcf.py
@@ -4,7 +4,6 @@ import os
 import sys
 import gzip
 from functools import lru_cache
-from typing import Iterable
 
 import bgzip
 
@@ -14,6 +13,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from tests import config  # initialize the test environment
 
 from terra_notebook_utils import drs
+from terra_notebook_utils.compat.typing import Iterable
 
 
 def partialize_vcf(uri: str, number_of_lines: int, zip_format: str="bgzip") -> bytes:

--- a/tests/test_copy_client.py
+++ b/tests/test_copy_client.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from unittest import mock
 from uuid import uuid4
-from typing import Dict, Iterable, Optional
+from typing import Dict, Optional
 
 from getm import default_chunk_size
 
@@ -19,6 +19,7 @@ from terra_notebook_utils.blobstore.gs import GSBlobStore, GSBlob
 from terra_notebook_utils.blobstore.local import LocalBlobStore, LocalBlob
 from terra_notebook_utils.blobstore.url import URLBlob
 from terra_notebook_utils.blobstore import BlobStore, copy_client
+from terra_notebook_utils.compat.typing import Iterable
 
 from tests import infra
 


### PR DESCRIPTION
Apparently the `typing` library is deprecating the `Iterable` type in python3.10, and the old import is failing our tests.