### PR TITLE
[ID-323] Allow tnu to use either Martha or DRSHub to resolve DRS URIs 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# Changes for v0.11.0 (2022-11-09)
+Added support for calling DRSHub for DRS resolution
+Made DRS Resolver configurable by setting `DRS_RESOLVER` to `martha` or `drshub`
+
 # Changes for v0.10.0 (2022-06-30)
 
 # Changes for v0.9.0 (2022-06-30)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This will run tests against Terra and Martha Dev using Jade Dev DRS url (make su
 This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
 
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
-4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod`
+4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod; export TNU_BLOBSTORE_TEST_GS_BUCKET=tnu-test-bucket`
 5. run in package root:
     - `make test`: skips controlled and dev access tests
     - `make controlled_access_test`: runs tests marked as `controlled_access`

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -5,6 +5,7 @@ WORKSPACE_NAMESPACE = os.environ.get('WORKSPACE_NAMESPACE')  # This env var is s
 WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra Cloud Environments
 TERRA_DEPLOYMENT_ENV = os.environ.get('TERRA_DEPLOYMENT_ENV', 'prod')
 MARTHA_URL_VERSION = os.environ.get('MARTHA_URL_VERSION', 'martha_v3')
+DRS_RESOLVER = os.environ.get('DRS_RESOLVER', 'martha')  # values for DRS_RESOLVER are either 'drshub' or 'martha'
 
 if not WORKSPACE_GOOGLE_PROJECT:
     WORKSPACE_GOOGLE_PROJECT = os.environ.get('GCP_PROJECT')  # Useful for running outside of notebook
@@ -20,3 +21,9 @@ if WORKSPACE_BUCKET is not None and WORKSPACE_BUCKET.startswith(_GS_SCHEMA):
 IO_CONCURRENCY = 3
 
 MARTHA_URL = f"https://us-central1-broad-dsde-{TERRA_DEPLOYMENT_ENV}.cloudfunctions.net/{MARTHA_URL_VERSION}"
+DRSHUB_URL = f"https://drshub.dsde-{TERRA_DEPLOYMENT_ENV}.broadinstitute.org/api/v4/drs/resolve"
+if DRS_RESOLVER == "martha":
+    DRS_RESOLVER_URL = MARTHA_URL
+else:
+    DRS_RESOLVER_URL = DRSHUB_URL
+

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -103,7 +103,8 @@ def access(drs_url: str,
         response = requests.get(drs_resolver_url, headers={'Range': 'bytes=0-1'})
         if response.status_code < 300:
             return drs_resolver_url
-        logger.warning('Received an invalid/inaccessible signed URL... attempting to generate an alternate signed URL...')
+        logger.warning('Received an invalid/inaccessible signed URL... '
+                       'attempting to generate an alternate signed URL...')
 
     url = gs.get_signed_url(bucket=info.bucket_name,
                             key=info.key,

--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -82,10 +82,10 @@ def get_signed_url(bucket: str,
     """
     default_service_account_credentials = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
 
-    # these are the service account credentials returned from Martha
+    # these are the service account credentials returned from the DRS Resolver
     if sa_credentials:
         creds = service_account.Credentials.from_service_account_info(sa_credentials)
-    # if Martha did not give us a service account, try the credentials set at GOOGLE_APPLICATION_CREDENTIALS
+    # if the DRS Resolver did not give us a service account, try the credentials set at GOOGLE_APPLICATION_CREDENTIALS
     elif default_service_account_credentials:
         creds = service_account.Credentials.from_service_account_file(default_service_account_credentials)
     # we can't access the file


### PR DESCRIPTION
This PR is to make the DRS resolver configurable, so DRS URIs can be resolved using either Martha or DRShub. You will be able to change the service called by updating the new env var `DRS_RESOLVER`

We are working on replacing Martha with DRSHub, so there will be a gradual cutover and eventually Martha will be deprecated. Behaviors should be the same between Martha and DRSHub so you shouldn't notice any difference when you cut over. We're still perf testing DRSHub so you don't need to flip the switch yet, someone will let you know when we're ready to swap. Please let me know if you have any questions about this! 