### PR TITLE
ID-1146 Remove Martha and Bond References

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# Changes for v0.14.0 (2024-03-33)
+Removed all references to Martha and Bond, which have been replace by DRSHub and External Credentials Manager, respectively.
+
 # Changes for v0.13.0 (2023-07-31)
 Removed `DRS_RESOLVER` environment variable, instead relying on `DRS_RESOLVER_ENDPOINT` to let the endpoint version be controlled externally.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ If you don't wish to run this within a docker image, skip to step 5.
     - `export TERRA_DEPLOYMENT_ENV=dev`
     - `export WORKSPACE_BUCKET=[bucketWithinWorkspace]`
     - `export GCLOUD_PROJECT=[validGoogleProject]` (set this if your DRS uri does not return Google SA)
-    - if you would like to run DRS methods against `martha_v2`, run `export MARTHA_URL_VERSION=martha_v2` (it is set to `martha_v3` by default)
 
 For Python API
   - run the python shell via `python`, and import any modules you wish to use. For example, `from terra_notebook_utils import drs`
@@ -239,7 +238,7 @@ This will run tests against Terra and DRSHub Dev using Jade Dev DRS url (make su
 
 **Test Env: Prod**
 
-This will run tests against Terra and Martha Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
+This will run tests against Terra and DRSHub Prod (make sure you have proper access to DRS urls, workspace and Google bucket)
 
 3. log in with your Google credentials using `gcloud auth application-default login` with your Terra Prod account
 4. set `export GOOGLE_PROJECT=firecloud-cgl; export TERRA_DEPLOYMENT_ENV=prod; export TNU_BLOBSTORE_TEST_GS_BUCKET=tnu-test-bucket`

--- a/terra_notebook_utils/__init__.py
+++ b/terra_notebook_utils/__init__.py
@@ -6,8 +6,7 @@ WORKSPACE_NAME = os.environ.get('WORKSPACE_NAME', None)
 WORKSPACE_NAMESPACE = os.environ.get('WORKSPACE_NAMESPACE')  # This env var is set in Terra Cloud Environments
 WORKSPACE_GOOGLE_PROJECT = os.environ.get('GOOGLE_PROJECT')  # This env var is set in Terra Cloud Environments
 TERRA_DEPLOYMENT_ENV = os.environ.get('TERRA_DEPLOYMENT_ENV', 'prod')
-MARTHA_URL_VERSION = os.environ.get('MARTHA_URL_VERSION', 'martha_v3')
-DRS_RESOLVER_ENDPOINT = os.environ.get("DRS_RESOLVER_ENDPOINT", None)
+DRS_RESOLVER_ENDPOINT = os.environ.get("DRS_RESOLVER_ENDPOINT", 'api/v4/drs/resolve')
 
 if not WORKSPACE_GOOGLE_PROJECT:
     WORKSPACE_GOOGLE_PROJECT = os.environ.get('GCP_PROJECT')  # Useful for running outside of notebook
@@ -22,13 +21,7 @@ if WORKSPACE_BUCKET is not None and WORKSPACE_BUCKET.startswith(_GS_SCHEMA):
 
 IO_CONCURRENCY = 3
 
-DEPRECATED_MARTHA_URL = f"https://us-central1-broad-dsde-{TERRA_DEPLOYMENT_ENV}.cloudfunctions.net/{MARTHA_URL_VERSION}"
-DRSHUB_URL = f"https://drshub.dsde-{TERRA_DEPLOYMENT_ENV}.broadinstitute.org/{DRS_RESOLVER_ENDPOINT}"
-
-if DRS_RESOLVER_ENDPOINT:
-    DRS_RESOLVER_URL = DRSHUB_URL
-else:
-    DRS_RESOLVER_URL = DEPRECATED_MARTHA_URL
+DRS_RESOLVER_URL = f"https://drshub.dsde-{TERRA_DEPLOYMENT_ENV}.broadinstitute.org/{DRS_RESOLVER_ENDPOINT}"
 
 class ExecutionEnvironment(Enum):
     TERRA_WORKSPACE = "TERRA_WORKSPACE",  # Executing in a Terra Workspace (on any supported platform)

--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -175,35 +175,8 @@ def _get_drs_gs_creds(response: dict) -> Optional[dict]:
     else:
         return None
 
-def _drs_info_from_martha_v2(drs_url: str, drs_data: dict) -> DRSInfo:
-    """Convert response from martha_v2 to DRSInfo."""
-    if 'data_object' in drs_data['dos']:
-        data_object = drs_data['dos']['data_object']
 
-        if 'urls' not in data_object:
-            raise DRSResolutionError(f"No GS url found for DRS uri '{drs_url}'")
-        else:
-            data_url = None
-            for url_info in data_object['urls']:
-                if 'url' in url_info and url_info['url'].startswith(_GS_SCHEMA):
-                    data_url = url_info['url']
-                    break
-            if data_url is None:
-                raise DRSResolutionError(f"No GS url found for DRS uri '{drs_url}'")
-
-        bucket_name, key = _parse_gs_url(data_url)
-        return DRSInfo(credentials=_get_drs_gs_creds(drs_data),
-                       access_url=None,
-                       checksums=None,
-                       bucket_name=bucket_name,
-                       key=key,
-                       name=data_object.get('name'),
-                       size=data_object.get('size'),
-                       updated=data_object.get('updated'))
-    else:
-        raise DRSResolutionError(f"No metadata was returned for DRS uri '{drs_url}'")
-
-def _drs_info_from_martha_v3_or_drshub(drs_url: str, drs_data: dict) -> DRSInfo:
+def _drs_info_from_drshub(drs_url: str, drs_data: dict) -> DRSInfo:
     """Convert DRS response to DRSInfo."""
     access_url: Optional[str] = None
     if drs_data.get('accessUrl') is not None:
@@ -236,10 +209,7 @@ def get_drs_info(drs_url: str, access_url: bool = False) -> DRSInfo:
     if access_url:
         fields.append("accessUrl")
     drs_data = get_drs(drs_url, fields).json()
-    if 'dos' in drs_data:
-        return _drs_info_from_martha_v2(drs_url, drs_data)
-    else:
-        return _drs_info_from_martha_v3_or_drshub(drs_url, drs_data)
+    return _drs_info_from_drshub(drs_url, drs_data)
 
 def get_drs_blob(drs_url_or_info: Union[str, DRSInfo],
                  billing_project: Optional[str]=WORKSPACE_GOOGLE_PROJECT) -> Union[GSBlob, URLBlob]:

--- a/terra_notebook_utils/gs.py
+++ b/terra_notebook_utils/gs.py
@@ -41,14 +41,14 @@ def get_access_token():
         token = creds.token
     return token
 
-def reset_bond_cache():
+def reset_ecm_cache():
     from terra_notebook_utils.http import http
     token = get_access_token()
     headers = {
         'authorization': f'Bearer {token}',
         'content-type': 'application/json'
     }
-    resp = http.delete(f'http://broad-bond-{TERRA_DEPLOYMENT_ENV}.appspot.com/api/link/v1/fence/', headers=headers)
+    resp = http.delete(f'https://externalcreds.dsde-{TERRA_DEPLOYMENT_ENV}.broadinstitute.org/api/oauth/v1/fence', headers=headers)
     print(resp.content)
 
 def get_client(credentials_data: dict | None = None, project: str | None = None):

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -157,90 +157,6 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
         }
     }
 
-    # martha_v2 responses
-    mock_martha_v2_response = {
-        'dos': {
-            'data_object': {
-                'aliases': [],
-                'checksums': [
-                    {
-                        'checksum': "8a366443",
-                        'type': "crc32c"
-                    }, {
-                        'checksum': "336ea55913bc261b72875bd259753046",
-                        'type': "md5"
-                    }
-                ],
-                'created': "2020-04-27T15:56:09.696Z",
-                'description': "",
-                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
-                'name': "my_data",
-                'mime_type': "",
-                'size': 15601108255,
-                'updated': "2020-04-27T15:56:09.696Z",
-                'urls': [
-                    {
-                        'url': 's3://my_bucket/my_data'
-                    },
-                    {
-                        'url': 'gs://bogus/my_data'
-                    }
-                ],
-                'version': "6d60cacf"
-            }
-        },
-        'googleServiceAccount': {
-            'data': {
-                'project_id': "foo"
-            }
-        }
-    }
-    mock_martha_v2_response_missing_fields = {
-        'dos': {
-            'data_object': {
-                'checksums': [
-                    {
-                        'checksum': "8a366443",
-                        'type': "crc32c"
-                    }, {
-                        'checksum': "336ea55913bc261b72875bd259753046",
-                        'type': "md5"
-                    }
-                ],
-                'created': "2020-04-27T15:56:09.696Z",
-                'description': "",
-                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
-                'mime_type': "",
-                'urls': [
-                    {
-                        'url': 'gs://bogus/my_data'
-                    }
-                ],
-                'version': "6d60cacf"
-            }
-        }
-    }
-    mock_martha_v2_response_without_gs_uri = {
-        'dos': {
-            'data_object': {
-                'checksums': [
-                    {
-                        'checksum': "8a366443",
-                        'type': "crc32c"
-                    }, {
-                        'checksum': "336ea55913bc261b72875bd259753046",
-                        'type': "md5"
-                    }
-                ],
-                'created': "2020-04-27T15:56:09.696Z",
-                'description': "",
-                'id': "dg.4503/00e6cfa9-a183-42f6-bb44-b70347106bbe",
-                'mime_type': "",
-                'version': "6d60cacf"
-            }
-        }
-    }
-
     def test_resolve_targets(self):
         expected_name = f"{uuid4()}"
         for name in (expected_name, None):
@@ -527,21 +443,6 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
             self.assertEqual(15601108255, actual_info.size)
             self.assertEqual('2020-04-27T15:56:09.696Z', actual_info.updated)
 
-    # test for when we get everything what we wanted in martha_v2 response
-    def test_martha_v2_response(self):
-        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response)
-        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
-        with ExitStack() as es:
-            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
-            es.enter_context(mock.patch("terra_notebook_utils.drs.http", post=requests_post))
-            actual_info = drs.get_drs_info(self.drs_url)
-            self.assertEqual({'project_id': "foo"}, actual_info.credentials)
-            self.assertEqual('bogus', actual_info.bucket_name)
-            self.assertEqual('my_data', actual_info.key)
-            self.assertEqual('my_data', actual_info.name)
-            self.assertEqual(15601108255, actual_info.size)
-            self.assertEqual('2020-04-27T15:56:09.696Z', actual_info.updated)
-
     # test for when some fields are missing in drs_resolver response
     def test_drs_resolver_response_with_missing_fields(self):
         resp_json = mock.MagicMock(return_value=self.mock_drs_resolver_response_missing_fields)
@@ -558,21 +459,6 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
             self.assertEqual(None, actual_info.size)
             self.assertEqual(None, actual_info.updated)
 
-    # test for when some fields are missing in martha_v2 response
-    def test_martha_v2_response_with_missing_fields(self):
-        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_missing_fields)
-        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
-        with ExitStack() as es:
-            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
-            es.enter_context(mock.patch("terra_notebook_utils.drs.http", post=requests_post))
-            actual_info = drs.get_drs_info(self.drs_url)
-            self.assertEqual(None, actual_info.credentials)
-            self.assertEqual('bogus', actual_info.bucket_name)
-            self.assertEqual('my_data', actual_info.key)
-            self.assertEqual(None, actual_info.name)
-            self.assertEqual(None, actual_info.size)
-            self.assertEqual(None, actual_info.updated)
-
     # test for when 'gsUrl' is missing in drs_resolver response. It should throw error
     @unittest.skip("TODO: Test no gsUri _and_ no accessUrl")
     def test_drs_resolver_response_without_gs_uri(self):
@@ -583,16 +469,6 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
             es.enter_context(mock.patch("terra_notebook_utils.drs.http", post=requests_post))
             with self.assertRaisesRegex(drs.DRSResolutionError, f"No GS url found for DRS uri '{self.jade_dev_url}'"):
                 drs.get_drs_blob(self.jade_dev_url)
-
-    # test for when no GS url is found in martha_v2 response. It should throw error
-    def test_martha_v2_response_without_gs_uri(self):
-        resp_json = mock.MagicMock(return_value=self.mock_martha_v2_response_without_gs_uri)
-        requests_post = mock.MagicMock(return_value=mock.MagicMock(status_code=200, json=resp_json))
-        with ExitStack() as es:
-            es.enter_context(mock.patch("terra_notebook_utils.drs.gs.get_client"))
-            es.enter_context(mock.patch("terra_notebook_utils.drs.http", post=requests_post))
-            with self.assertRaisesRegex(Exception, f"No GS url found for DRS uri '{self.drs_url}'"):
-                drs.get_drs_blob(self.drs_url)
 
     # test for when drs_resolver returns error. It should throw error
     def test_drs_resolver_error_response(self):
@@ -659,7 +535,7 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
             response.raise_for_status()
         # Test a Jade resource
         # requires that GOOGLE_APPLICATION_CREDENTIALS be set
-        # because neither martha nor DRSHub returns a service account
+        # because DRSHub does not return a service account
         jade_uri = 'drs://jade-terra.datarepo-prod.broadinstitute.org/' \
                    'v1_c3c588a8-be3f-467f-a244-da614be6889a_635984f0-3267-4201-b1ee-d82f64b8e6d1'
         with self.subTest(f'Testing DRS Access: {jade_uri}'):

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -18,8 +18,8 @@ class TestTerraNotebookUtilsGS(SuppressWarningsMixin, unittest.TestCase):
     def test_get_access_token(self):
         gs.get_access_token()
 
-    def test_reset_bond_cache(self):
-        gs.reset_bond_cache()
+    def test_reset_ecm_cache(self):
+        gs.reset_ecm_cache()
 
     def test_get_client(self):
         gs.get_client()


### PR DESCRIPTION
Bond and Martha are no longer in service. They have been replaced with External Credentials Manager and DRSHub, respectively. References to Bond and Martha are no longer needed, so they are being removed.