### PR TITLE
Unpin bgzip upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ azure-identity >= 1.12.0, < 2
 google-cloud-storage >= 1.38.0, < 2
 gs-chunked-io >= 0.5.1, < 0.6
 firecloud
-bgzip >= 0.3.5, < 0.4
+bgzip >= 0.3.5
 cli-builder >= 0.1.5, < 0.2
 oauth2client
 jmespath == 0.10.0


### PR DESCRIPTION
Encountered issue while building new AnVIL Bioconductor RStudio Docker image.
With the pinned version, it tries to install an older bgzip which fails:
```
      x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/opt/venv/include -I/usr/include/python3.12 -c bgzip_utils/bgzip_utils.c -o build/temp.linux-x86_64-cpython-312/bgzip_utils/bgzip_utils.o -O3 -fopenmp
      bgzip_utils/bgzip_utils.c:196:12: fatal error: longintrepr.h: No such file or directory
        196 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for bgzip
```

Unpinning it seems to fix the problem and TNU installs as expected.