### PR TITLE
Refine usage docs for `drs` module help

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ terra-notebook-utils exposes a Python API, as well as wrappers to execute some f
 API is best explored with Pythons great `help` function. For instance, issuing the follow commands into a Python
 interpreter or Jupyter notebook will produce help and usage for the `drs` module.
 ```
-import terra_notebook_utils as tnu
-help(tnu.drs)
+import terra_notebook_utils.drs as drs
+help(drs)
 ```
 
 Similarly, the CLI may be explored using the typical `-h` argument. Try the following commands at a bash prompt.


### PR DESCRIPTION
This library is a gem for working with DRS URIs, like AnVIL data!  While working with it, I encountered a bug in the README.

> terra-notebook-utils exposes a Python API, as well as wrappers to execute some functionality on the CLI. The Python API is best explored with Pythons great `help` function. For instance, issuing the follow commands into a Python interpreter or Jupyter notebook will produce help and usage for the `drs` module.
`import terra_notebook_utils as tnu`
`help(tnu.drs)`

The problem is that `help(tnu.drs)` throws an error unless you've previously imported the `drs` module.  Fix:
```
import terra_notebook_utils.drs as drs
help(drs)
```

[Slack discussion](https://broadinstitute.slack.com/archives/C07RK8KNWMV/p1743082417553049) has a bit more context and brief video demo of the bug and fix.