### PR TITLE
CTM-381:Always send the workspace google project to the DRSHub request body

### DIFF
--- a/terra_notebook_utils/drs.py
+++ b/terra_notebook_utils/drs.py
@@ -111,6 +111,8 @@ def get_drs(drs_url: str, fields: List[str]) -> Response:
     cloud_platform = get_drs_cloud_platform()
     if cloud_platform:
         json_body["cloudPlatform"] = cloud_platform
+    if WORKSPACE_GOOGLE_PROJECT:
+        json_body["userProject"] = WORKSPACE_GOOGLE_PROJECT
     resp = http.post(DRS_RESOLVER_URL, headers=headers, json=json_body)
 
     if 200 != resp.status_code:

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -446,7 +446,8 @@ class TestTerraNotebookUtilsDRS(SuppressWarningsMixin, unittest.TestCase):
 
             args, kwargs = requests_post.call_args
             self.assertEqual(kwargs['headers'].get('X-App-ID'), 'terra_notebook_utils')
-            expected_json_body = dict(url=self.jade_dev_url, cloudPlatform="gs", fields=fields)
+            expected_json_body = dict(url=self.jade_dev_url, cloudPlatform="gs", fields=fields,
+                                     userProject=terra_notebook_utils.WORKSPACE_GOOGLE_PROJECT)
             self.assertEqual(kwargs['json'], expected_json_body)
 
             self.assertEqual(None, actual_info.credentials)


### PR DESCRIPTION
Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-381

All TDR clients via DRSHub should now pass the Google Project ID of the requester so the DRSHub resolution can then be billed appropriately if requester pay is enabled.
